### PR TITLE
DAS-1877 - Implement GitHub CI/CD for earthdata-varinfo.

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,0 +1,54 @@
+name: Publish earthdata-varinfo to PyPI
+
+on:
+  push:
+    branches: [ main ]
+    paths: VERSION
+  workflow_dispatch:
+
+jobs:
+  run_tests:
+    uses: ./.github/workflows/run_tests.yml
+
+  publish_to_pypi:
+    needs: run_tests
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout earthdata-varinfo repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Extract semantic version number
+        run: echo "semantic_version=$(cat VERSION)" >> $GITHUB_ENV
+
+      - name: Extract release version notes
+        run: |
+          version_release_notes=$(./bin/extract-release-notes.sh)
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
+          echo "${version_release_notes}" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Build earthdata-varinfo release
+        run: make build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Publish GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          body: ${{ env.RELEASE_NOTES }}
+          commit: main
+          name: Version ${{ env.semantic_version }}
+          tag: ${{ env.semantic_version }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,39 @@
+name: Run Python unit tests
+
+on:
+  workflow_call
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.9', '3.10', '3.11', '3.x' ]
+      fail-fast: false
+
+    steps:
+      - name: Checkout harmony-gdal-adapter repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Run tests
+        run: make test 
+
+      - name: Archive test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test results for Python ${{ matrix.python-version }}
+          path: tests/reports/
+
+      - name: Archive coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: Coverage report for Python ${{ matrix.python-version }}
+          path: tests/coverage/

--- a/.github/workflows/run_tests_on_pull_requests.yml
+++ b/.github/workflows/run_tests_on_pull_requests.yml
@@ -1,0 +1,9 @@
+name: Run Python unit tests for pull requests against main
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build_and_test:
+    uses: ./.github/workflows/run_tests.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v1.0.0
-### Unreleased
+### 2023-06-16
 
 This version of `earthdata-varinfo` contains all functionality previous
 released as `sds-varinfo==4.1.1`, but resets the version number to begin

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 # Things to include in the build package, in addition to the package defined in
 # setup.py
+include requirements.txt
+include dev-requirements.txt
 include CHANGELOG.md
 include README.md
 include VERSION

--- a/Makefile
+++ b/Makefile
@@ -5,26 +5,23 @@
 # from within a Docker container.
 #
 ###############################################################################
-.PHONY: clean build publish test develop
-
-REPO ?= https://upload.pypi.org/legacy/
-REPO_USER ?= unset
-REPO_PASS ?= unset
+.PHONY: clean build test develop install
 
 build: clean
 	python -m pip install --upgrade pip
 	python -m pip install --upgrade --quiet setuptools wheel twine
-	python setup.py --quiet sdist bdist_wheel
-
-publish: build
-	python -m twine check dist/*
-	python -m twine upload --username "$(REPO_USER)" --password "$(REPO_PASS)" --repository-url "$(REPO)" dist/*
+	python -m pip install --upgrade --quiet build
+	python -m build
 
 clean:
 	rm -rf build dist *.egg-info || true
 
 develop:
 	pip install -e .[dev]
+
+install:
+	python -m pip install --upgrade pip
+	pip install -r requirements.txt -r dev-requirements.txt
 
 lint:
 	pylint varinfo --extension-pkg-whitelist=netCDF4

--- a/README.md
+++ b/README.md
@@ -156,12 +156,30 @@ Run `unittest` suite:
 
 ```bash
 $ make test
-```
+````
 
 ## Releasing:
 
-All CI/CD for this repository will be defined in the `.github/workflows`
-directory. Before triggering a release, ensure the `VERSION` and `CHANGELOG.md`
+All CI/CD for this repository is defined in the `.github/workflows` directory:
+
+* run_tests.yml - A reusable workflow that runs the unit test suite under a
+  matrix of Python versions.
+* run_tests_on_pull_requests.yml - Triggered for all PRs against main. It runs
+  the workflow in run_test.yml to ensure all tests pass on the new code.
+* publish_to_pypi.yml - Triggered either manually or for commits to the main
+  branch that contain changes to the `VERSION` file.
+
+The `publish_to_pypi.yml` workflow will:
+
+* Run the full unit test suite, to prevent publication of broken code.
+* Extract the semantic version number from `VERSION`.
+* Extract the release notes for the most recent version from `CHANGELOG.md`.
+* Build the package to be published to PyPI.
+* Publish the package to PyPI.
+* Publish a GitHub release under the semantic version number, with associated
+  git tag.
+
+Before triggering a release, ensure the `VERSION` and `CHANGELOG.md`
 files are updated accordingly.
 
 ## Get in touch:

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Run `unittest` suite:
 
 ```bash
 $ make test
-````
+```
 
 ## Releasing:
 

--- a/bin/extract-release-notes.sh
+++ b/bin/extract-release-notes.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+###############################################################################
+#
+# A bash script to extract only the notes related to the most recent version of
+# earthdata-varinfo from CHANGELOG.md
+#
+# 2023-06-16: Created
+#
+###############################################################################
+
+CHANGELOG_FILE="CHANGELOG.md"
+VERSION_PATTERN="^## v"
+# Count number of versions in version file:
+number_of_versions=$(grep -c "${VERSION_PATTERN}" ${CHANGELOG_FILE})
+
+if [ ${number_of_versions} -gt 1 ]
+then
+	grep -B 9999 -m2 "${VERSION_PATTERN}" ${CHANGELOG_FILE} | sed '$d' | sed '$d'
+else
+	cat ${CHANGELOG_FILE}
+fi

--- a/bin/extract-release-notes.sh
+++ b/bin/extract-release-notes.sh
@@ -15,7 +15,7 @@ number_of_versions=$(grep -c "${VERSION_PATTERN}" ${CHANGELOG_FILE})
 
 if [ ${number_of_versions} -gt 1 ]
 then
-	grep -B 9999 -m2 "${VERSION_PATTERN}" ${CHANGELOG_FILE} | sed '$d' | sed '$d'
+	grep -B 9999 -m 2 "${VERSION_PATTERN}" ${CHANGELOG_FILE} | sed '$d' | sed '$d'
 else
 	cat ${CHANGELOG_FILE}
 fi


### PR DESCRIPTION
## Description

This PR implements CI/CD for `earthdata-varinfo` that was previously captured in Bamboo for the equivalent Bitbucket repository. There are two main workflows:

* All unit tests should be run when a PR is published against `main`.
* A PyPI and GitHub release should be created when a new commit in the `main` branch contains changes to `VERSION` (or when manually invoked by a maintainer).

Both of the above workflows use the reusable `run_tests.yml` workflow to keep the CI/CD DRY.

See the "Easy Way" [here](https://docs.pypi.org/trusted-publishers/using-a-publisher/) for more information on publishing to PyPI. I have set up the trusted publisher within PyPI in anticipation of attempted publication.

## Jira Issue ID

DAS-1877

## Local Test Steps

* Confirm that this PR triggered the running of unit tests, and that they all passed under the multiple Python versions.
* Look at the actions in [my copy of this repository](https://github.com/owenlittlejohns/earthdata-varinfo) to confirm that the publication workflow was successful. Note - the publication to PyPI was commented out in those tests.

## PR Acceptance Checklist
* [x] Jira ticket acceptance criteria met.
* [x] `CHANGELOG.md` updated to include high level summary of PR changes.
* ~~`VERSION` updated if publishing a release.~~ (I'll trigger this one manually, as the version file is already at the correct version)
* [x] Tests added/updated and passing.
* [x] Documentation updated (if needed).