### PR TITLE
Clarify UMM-Var JSON generation in README, add reference to documentation notebook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ capability to generate variable (UMM-Var) metadata records that are compatible
 with the NASA EOSDIS Common Metadata Repository
 ([CMR](https://www.earthdata.nasa.gov/eosdis/science-system-description/eosdis-components/cmr)).
 
+For general usage of classes and functions in `earthdata-varinfo`, see:
+<https://github.com/nasa/earthdata-varinfo/blob/main/docs/earthdata-varinfo.ipynb>.
+
 ## Features:
 
 ### CFConfig
@@ -84,8 +87,14 @@ CMR UMM-Var schema:
 from varinfo import VarInfoFromNetCDF4
 from varinfo.umm_var import export_all_umm_var_to_json, get_all_umm_var
 
+# Instantiate a VarInfoNetCDF4 object for a local NetCDF-4 file.
 var_info = VarInfoFromNetCDF4('/path/to/local/file.nc4', short_name='ATL03')
+
+# Retrieve a dictionary of UMM-Var JSON records. Keys are the full variable
+# paths, values are UMM-Var schema-compatible, JSON-serialisable dictionaries.
 umm_var = get_all_umm_var(var_info)
+
+# Write each UMM-Var dictionary to its own JSON file:
 export_all_umm_var_to_json(list(umm_var.values()), output_dir='local_dir')
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ CMR UMM-Var schema:
 from varinfo import VarInfoFromNetCDF4
 from varinfo.umm_var import export_all_umm_var_to_json, get_all_umm_var
 
-# Instantiate a VarInfoNetCDF4 object for a local NetCDF-4 file.
+# Instantiate a VarInfoFromNetCDF4 object for a local NetCDF-4 file.
 var_info = VarInfoFromNetCDF4('/path/to/local/file.nc4', short_name='ATL03')
 
 # Retrieve a dictionary of UMM-Var JSON records. Keys are the full variable


### PR DESCRIPTION
## Description

This PR addresses recent feedback that stated it wasn't clear how to get the UMM-Var records in-memory with `earthdata-varinfo`. I've added comments to the snippet in the README that better describe the functions being used. There is also more extensive discussion of UMM-Var generation functionality in the Jupyter notebook hosted in the `docs` directory, so I referred to that notebook in the README, too.

## Jira Issue ID
N/A

## Local Test Steps
N/A

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* ~~`CHANGELOG.md` updated to include high level summary of PR changes.~~
* ~~`VERSION` updated if publishing a release.~~
* ~~Tests added/updated and passing.~~
* [x] Documentation updated (if needed).