### PR TITLE
DAS-1894

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,13 @@ __pycache__/
 
 # Generated files
 stash
+downloaded_granules
+*.nc4
+*.nc
+*.grb
+*.he5
+*.h5
+*.hdf5
 
 # VS Code
 .vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.0.2
+# Added
+    In `cmr_search.py` added functions `get_granule_name` and `download_granule`
+    In `test_cmr_search.py added functions: `test_granule_name`, `test_download_gran_exceptions`, 
+    `mock_requests`, and `test_requests_error`.
+
+
 ## v1.0.1
 # Added
     `cmr_search` and `test_cmr_search.py`

--- a/varinfo/exceptions.py
+++ b/varinfo/exceptions.py
@@ -65,7 +65,7 @@ class MissingConfigurationFileError(CustomError):
 
 
 class CMRQueryException(CustomError):
-    ''' This exception is raised when a query to CMR fails. 
+    ''' This exception is raised when a query to CMR fails.
     '''
 
     def __init__(self, cmr_exception_message):
@@ -91,3 +91,12 @@ class MissingGranuleDownloadLinks(CustomError):
     def __init__(self, download_link):
         super().__init__('MissingGranuleDownloadLinks',
                          f'No links for granule record: {download_link}')
+
+
+class RequestsException(CustomError):
+    ''' This exception is raised when a query to CMR fails.
+    '''
+
+    def __init__(self, requests_exception_message):
+        super().__init__('RequestsException',
+                         f'requests module failed with the following error: {requests_exception_message}')


### PR DESCRIPTION
## Description
Added functionality for downloading a granule locally from CMR 

## Jira Issue ID
DAS-1894

## Local Test Steps
```
# Import CMR query and environment types
from cmr import GranuleQuery, CMR_UAT
import requests
from varinfo.cmr_search import get_granules, get_granule_name, get_granule_link, download_granule

granule_response = get_granules(concept_id='G1245662789-EEDTEST',
                                cmr_env=CMR_UAT,
                                token=token_uat) # Change token to your UAT token

link = get_granule_link(granule_response)
download_granule(link, get_granule_name(granule_response)) # Saves to your current directory
```

## PR Acceptance Checklist
* [ X] Jira ticket acceptance criteria met.
* [ X] `CHANGELOG.md` updated to include high level summary of PR changes.
* [ ] `VERSION` updated if publishing a release.
* [ X] Tests added/updated and passing.
* [ ] Documentation updated (if needed).
