### PR TITLE
DAS-1894

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,13 @@ __pycache__/
 
 # Generated files
 stash
+downloaded_granules
+*.nc4
+*.nc
+*.grb
+*.he5
+*.h5
+*.hdf5
 
 # VS Code
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -23,12 +23,12 @@ __pycache__/
 # Generated files
 stash
 downloaded_granules
-*.nc4
-*.nc
-*.grb
-*.he5
-*.h5
-*.hdf5
+/*.nc4
+/*.nc
+/*.grb
+/*.he5
+/*.h5
+/*.hdf5
 
 # VS Code
 .vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,8 @@
-## v1.0.2
-# Added
-    In `cmr_search.py` added functions `get_granule_name` and `download_granule`
-    In `test_cmr_search.py added functions: `test_granule_name`, `test_download_gran_exceptions`, 
-    `mock_requests`, and `test_requests_error`.
-
-
 ## v1.0.1
-# Added
-    `cmr_search` and `test_cmr_search.py`
-
+### Unreleased
+Added `cmr_search` and `test_cmr_search.py`
+#### 2023-08-23
+Added function `download_granule` to `cmr_search.py`
 
 ## v1.0.0
 ### 2023-06-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.0.2
+# Added
+    In `cmr_search.py` added functions `get_granule_name` and `download_granule`
+    In `test_cmr_search.py added functions: `test_granule_name`, `test_download_gran_exceptions`, 
+    `mock_requests`, and `test_requests_error`.
+
+
 ## v1.0.1
 # Added
     `cmr_search` and `test_cmr_search.py`

--- a/varinfo/exceptions.py
+++ b/varinfo/exceptions.py
@@ -95,10 +95,20 @@ class MissingGranuleDownloadLinks(CustomError):
 
 
 class GranuleDownloadException(CustomError):
-    ''' This exception is raised when a query to CMR fails.
+    ''' This exception is raised when the requests modules fails.
     '''
 
     def __init__(self, granule_download_exception_message):
         super().__init__('GranuleDownloadException',
                          'requests module failed with the following error: '
                          f'{granule_download_exception_message}')
+
+
+class DirectoryCreationException(CustomError):
+    ''' This exception is raised when creating a directory fails.
+    '''
+
+    def __init__(self, directory_creation_exception_message):
+        super().__init__('DirectoryCreationException',
+                         'directory creation failed with the following error: '
+                         f'{directory_creation_exception_message}')

--- a/varinfo/exceptions.py
+++ b/varinfo/exceptions.py
@@ -70,7 +70,8 @@ class CMRQueryException(CustomError):
 
     def __init__(self, cmr_exception_message):
         super().__init__('CMRQueryException',
-                         f'CMR query failed with the following error: {cmr_exception_message}')
+                         'CMR query failed with the following error: '
+                         f'{cmr_exception_message}')
 
 
 class MissingPositionalArguments(CustomError):
@@ -93,10 +94,11 @@ class MissingGranuleDownloadLinks(CustomError):
                          f'No links for granule record: {download_link}')
 
 
-class RequestsException(CustomError):
+class GranuleDownloadException(CustomError):
     ''' This exception is raised when a query to CMR fails.
     '''
 
-    def __init__(self, requests_exception_message):
-        super().__init__('RequestsException',
-                         f'requests module failed with the following error: {requests_exception_message}')
+    def __init__(self, granule_download_exception_message):
+        super().__init__('GranuleDownloadException',
+                         'requests module failed with the following error: '
+                         f'{granule_download_exception_message}')

--- a/varinfo/exceptions.py
+++ b/varinfo/exceptions.py
@@ -65,7 +65,7 @@ class MissingConfigurationFileError(CustomError):
 
 
 class CMRQueryException(CustomError):
-    ''' This exception is raised when a query to CMR fails. 
+    ''' This exception is raised when a query to CMR fails.
     '''
 
     def __init__(self, cmr_exception_message):
@@ -91,3 +91,12 @@ class MissingGranuleDownloadLinks(CustomError):
     def __init__(self, download_link):
         super().__init__('MissingGranuleDownloadLinks',
                          f'No links for granule record: {download_link}')
+
+
+class RequestsException(CustomError):
+    ''' This exception is raised when a query to CMR fails.
+    '''
+
+    def __init__(self, requests_exception_message):
+        super().__init__('RequestsException',
+                         f'requests module failed with the following error: {requests_exception_message}')


### PR DESCRIPTION
**Description**
Added functionality for downloading a granule locally from CMR

**Jira Issue ID**
DAS-1894

**Local Test Steps**

```
# Import environment types
from cmr import CMR_UAT

from varinfo.cmr_search import get_granules, get_granule_link, download_granule

granule_response = get_granules(concept_id='G1245662789-EEDTEST',
                                cmr_env=CMR_UAT,
                                token=token_uat) # Change token to your UAT token

link = get_granule_link(granule_response)
# Saves to your current directory and returns path of saved file
download_granule(link, token=token_uat)
# Uncomment and change out_directory to prefered path
# download_granule(link,  token=token_uat, out_directory='/Foo/User/selected/out/directory')
```


**PR Acceptance Checklist**
[ X] Jira ticket acceptance criteria met.
[ X] CHANGELOG.md updated to include high level summary of PR changes.
 VERSION updated if publishing a release.
[ X] Tests added/updated and passing.
 Documentation updated (if needed).