### PR TITLE
Add requests to requirements.txt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## vX.Y.Z
+### Unreleased
+
+The `requests` package has been added as an explicit dependency of the package.
+
 ## v2.2.0
 ### 2023-11-30
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 netCDF4 ~= 1.6.3
 numpy ~= 1.24.2
 python-cmr ~= 0.9.0
+requests ~= 2.31.0


### PR DESCRIPTION
## Description

This PR addresses an issue that @eni-awowale found. We explicitly call the `requests` package in the UMM-Var and CMR related work added in PI 23.4, but we only have that available as a dependency of another package. To fix that, I've added `requests` explicitly to our `requirements.txt`. Thanks, @eni-awowale, for finding this!

I'm not sure what people thing about cutting a release, as it's kind of a no-op change?

## Jira Issue ID

N/A

## Local Test Steps

* Pull this branch.
* Create a new empty Python environment (no installed packages).
* Run `make install && make test`. The tests should pass.

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* [x] `CHANGELOG.md` updated to include high level summary of PR changes.
* [ ] `VERSION` updated if publishing a release. *Thoughts on this?*
* [x] Tests ~~added/updated and~~ passing.
* ~~Documentation updated (if needed).~~