### PR TITLE
IP-242 - Add .snyk file.

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+language-settings:
+  python: "3.11"


### PR DESCRIPTION
## Description

This PR builds on some work that @flamingbear has done in other repositories to add a `.snyk` file that will ensure Snyk uses a specified version of Python when building an environment to scan the `earthdata-varinfo` dependency tree. Note - earthdata-varinfo is installed in other people's environments, which can have one of a number of Python versions, so I've opted for Python 3.11, which is the most recent version of Python our unit tests run under (we currently run tests under 3.9, 3.10 and 3.11).

This change only relates to our CI/CD and does not impact any delivered code (so it doesn't need a release or updated notes in the change log).

## Jira Issue ID

N/A

## Local Test Steps

N/A

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* ~~`CHANGELOG.md` updated to include high level summary of PR changes.~~
* ~~`VERSION` updated if publishing a release.~~
* ~~Tests added/updated and passing.~~
* ~~Documentation updated (if needed).~~