### PR TITLE
TRT-554 - Flatten overrides and supplements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,21 @@
 ## v3.0.0
 ### Unreleased
 
-Groups within a NetCDF-4 or DMR file are now assigned to the `VarInfo*.groups`
+The configuration file schema for `earthdata-varinfo` is significantly updated
+in this release. For more information, see the release notes for schema v1.0.0
+in `config/CHANGELOG.md`.
+
+### Added:
+
+* Groups within a NetCDF-4 or DMR file are now assigned to the `VarInfo*.groups`
 dictionary, allowing for their metadata attributes to be accessed after parsing
 an input file.
 
-The configuration file schema is simplified in accordance with the new handling
-of groups, which is more aligned with the handling of variables.
+### Changed:
+
+* Handling of nested `Applicability_Groups` has been removed from the `CFConfig`
+  class, as the configuration file no longer nests these items in overrides
+  or supplements.
 
 ## v2.2.2
 ### 2024-07-16

--- a/config/1.0.0/earthdata_varinfo_configuration_schema.json
+++ b/config/1.0.0/earthdata_varinfo_configuration_schema.json
@@ -227,8 +227,6 @@
         "required": ["Mission"]
       }, {
         "required": ["ShortNamePath"]
-      }, {
-        "required": ["Variable_Pattern"]
       }],
       "additionalProperties": false
     },

--- a/config/1.0.0/earthdata_varinfo_configuration_schema.json
+++ b/config/1.0.0/earthdata_varinfo_configuration_schema.json
@@ -317,40 +317,6 @@
             "description": "A list of metadata attributes with their names and values.",
             "$ref": "#/$defs/AttributesItemType"
           }
-        },
-        "Applicability_Group": {
-          "description": "A more stringent applicability role that will also include a variable path, allowing for overwriting or supplementing the metadata attribute of a subset of variables within a granule.",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ApplicabilityGroupItemType"
-          }
-        }
-      },
-      "additionalProperties": false,
-      "anyOf": [{
-        "required": ["Applicability", "Applicability_Group"]
-      }, {
-        "required": ["Applicability", "Attributes"]
-      }]
-    },
-    "ApplicabilityGroupItemType": {
-      "description": "An object to overwrite or supplement metadata attributes for variables matching a specific string or regular expression.",
-      "type": "object",
-      "properties": {
-        "Applicability": {
-          "description": "An applicability rule including a variable path as a regular expression or string.",
-          "$ref": "#/$defs/ApplicabilityType"
-        },
-        "Attributes": {
-          "description": "A list of metadata attribute names and the values that will be used to either append to or update the existing metadata attributes.",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/AttributesItemType"
-          }
-        },
-        "_Description": {
-          "description": "A description of the need for and effect of the specific applicability group.",
-          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/config/1.0.0/sample_config_1.0.0.json
+++ b/config/1.0.0/sample_config_1.0.0.json
@@ -88,30 +88,26 @@
     {
       "Applicability": {
         "Mission": "SMAP",
-        "ShortNamePath": "SPL3FT(P|P_E)"
+        "ShortNamePath": "SPL3FT(P|P_E)",
+        "Variable_Pattern": "(?i).*global.*"
       },
-      "Applicability_Group": [
+      "Attributes": [
         {
-          "Applicability": {
-            "Variable_Pattern": "(?i).*global.*"
-          },
-          "Attributes": [
-            {
-              "Name": "Grid_Mapping",
-              "Value": "EASE2_Global"
-            }
-          ]
-        },
+          "Name": "Grid_Mapping",
+          "Value": "EASE2_Global"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FT(P|P_E)",
+        "Variable_Pattern": "(?i).*polar.*"
+      },
+      "Attributes": [
         {
-          "Applicability": {
-            "Variable_Pattern": "(?i).*polar.*"
-          },
-          "Attributes": [
-            {
-              "Name": "Grid_Mapping",
-              "Value": "EASE2_Polar"
-            }
-          ]
+          "Name": "Grid_Mapping",
+          "Value": "EASE2_Polar"
         }
       ]
     },
@@ -188,126 +184,129 @@
     {
       "Applicability": {
         "Mission": "ICESat2",
-        "ShortNamePath": "ATL0[3-9]|ATL1[023]"
+        "ShortNamePath": "ATL0[3-9]|ATL1[023]",
+        "Variable_Pattern": "/$"
       },
-      "Applicability_Group": [
+      "Attributes": [
         {
-          "Applicability": {
-            "Variable_Pattern": "/$"
-          },
-          "Attributes": [
-            {
-              "Name": "Data_Organization",
-              "Value": "h5_trajectory"
-            }
-          ]
+          "Name": "Data_Organization",
+          "Value": "h5_trajectory"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "ICESat2",
+        "ShortNamePath": "ATL0[3-9]|ATL1[023]",
+        "Variable_Pattern": "/gt[123][lr]/geolocation/.*"
+      },
+      "Attributes": [
+        {
+          "Name": "ancillary_variables",
+          "Value": "podppd_flag"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "ICESat2",
+        "ShortNamePath": "ATL03",
+        "Variable_Pattern": "/gt[123][lr]/geophys_corr/.*"
+      },
+      "Attributes": [
+        {
+          "Name": "subset_control_variables",
+          "Value": "../geolocation/delta_time, ../geolocation/reference_photon_lat, ../geolocation/reference_photon_lon"
         },
         {
-          "Applicability": {
-            "Variable_Pattern": "/gt[123][lr]/geolocation/.*"
-          },
-          "Attributes": [
-            {
-              "Name": "ancillary_variables",
-              "Value": "podppd_flag"
-            }
-          ]
+          "Name": "subset_control_type",
+          "Value": "coordinates"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "ICESat2",
+        "ShortNamePath": "ATL03",
+        "Variable_Pattern": "/gt[123][lr]/heights/.*"
+      },
+      "Attributes": [
+        {
+          "Name": "subset_control_variables",
+          "Value": "../geolocation/ph_index_beg, ../geolocation/segment_ph_cnt"
         },
         {
-          "Applicability": {
-            "ShortNamePath": "ATL03",
-            "Variable_Pattern": "/gt[123][lr]/geophys_corr/.*"
-          },
-          "Attributes": [
-            {
-              "Name": "subset_control_variables",
-              "Value": "../geolocation/delta_time, ../geolocation/reference_photon_lat, ../geolocation/reference_photon_lon"
-            },
-            {
-              "Name": "subset_control_type",
-              "Value": "coordinates"
-            }
-          ]
+          "Name": "subset_control_type",
+          "Value": "fwd_segment_index"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "ICESat2",
+        "ShortNamePath": "ATL03",
+        "Variable_Pattern": "/gt[123][lr]/geolocation/ph_index_beg"
+      },
+      "Attributes": [
+        {
+          "Name": "subset_control_variable_type",
+          "Value": "segment_index_beg"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "ICESat2",
+        "ShortNamePath": "ATL03",
+        "Variable_Pattern": "/gt[123][lr]/geolocation/ph_index_beg"
+      },
+      "Attributes": [
+        {
+          "Name": "subset_control_variable_type",
+          "Value": "segment_index_cnt"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "ICESat2",
+        "ShortNamePath": "ATL08",
+        "Variable_Pattern": "/gt[123][lr]/signal_photons/.*"
+      },
+      "Attributes": [
+        {
+          "Name": "subset_control_variables",
+          "Value": "../land_segments/ph_ndx_beg, ../land_segments/n_seg_ph"
         },
         {
-          "Applicability": {
-            "ShortNamePath": "ATL03",
-            "Variable_Pattern": "/gt[123][lr]/heights/.*"
-          },
-          "Attributes": [
-            {
-              "Name": "subset_control_variables",
-              "Value": "../geolocation/ph_index_beg, ../geolocation/segment_ph_cnt"
-            },
-            {
-              "Name": "subset_control_type",
-              "Value": "fwd_segment_index"
-            }
-          ]
-        },
+          "Name": "subset_control_type",
+          "Value": "fwd_segment_index"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "ICESat2",
+        "ShortNamePath": "ATL08",
+        "Variable_Pattern": "/gt[123][lr]/land_segments/ph_ndx_beg"
+      },
+      "Attributes": [
         {
-          "Applicability": {
-            "ShortNamePath": "ATL03",
-            "Variable_Pattern": "/gt[123][lr]/geolocation/ph_index_beg"
-          },
-          "Attributes": [
-            {
-              "Name": "subset_control_variable_type",
-              "Value": "segment_index_beg"
-            }
-          ]
-        },
+          "Name": "subset_control_variable_type",
+          "Value": "segment_index_beg"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "ICESat2",
+        "ShortNamePath": "ATL08",
+        "Variable_Pattern": "/gt[123][lr]/land_segments/n_seg_ph"
+      },
+      "Attributes": [
         {
-          "Applicability": {
-            "ShortNamePath": "ATL03",
-            "Variable_Pattern": "/gt[123][lr]/geolocation/ph_index_beg"
-          },
-          "Attributes": [
-            {
-              "Name": "subset_control_variable_type",
-              "Value": "segment_index_cnt"
-            }
-          ]
-        },
-        {
-          "Applicability": {
-            "ShortNamePath": "ATL08",
-            "Variable_Pattern": "/gt[123][lr]/signal_photons/.*"
-          },
-          "Attributes": [
-            {
-              "Name": "subset_control_variables",
-              "Value": "../land_segments/ph_ndx_beg, ../land_segments/n_seg_ph"
-            },
-            {
-              "Name": "subset_control_type",
-              "Value": "fwd_segment_index"
-            }
-          ]
-        },
-        {
-          "Applicability": {
-            "ShortNamePath": "ATL08",
-            "Variable_Pattern": "/gt[123][lr]/land_segments/ph_ndx_beg"
-          },
-          "Attributes": [
-            {
-              "Name": "subset_control_variable_type",
-              "Value": "segment_index_beg"
-            }
-          ]
-        },
-        {
-          "Applicability": {
-            "ShortNamePath": "ATL08",
-            "Variable_Pattern": "/gt[123][lr]/land_segments/n_seg_ph"
-          },
-          "Attributes": [
-            {
-              "Name": "subset_control_variable_type",
-              "Value": "segment_index_cnt"
-            }
-          ]
+          "Name": "subset_control_variable_type",
+          "Value": "segment_index_cnt"
         }
       ]
     },
@@ -335,18 +334,18 @@
           "Name": "Data_Organization",
           "Value": "h5_grid"
         }
-      ],
-      "Applicability_Group": [
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "ICESat2",
+        "ShortNamePath": "ATL20",
+        "Variable_Pattern": ".*"
+      },
+      "Attributes": [
         {
-          "Applicability": {
-            "Variable_Pattern": ".*"
-          },
-          "Attributes": [
-            {
-              "Name": "coordinates",
-              "Value": "/crs"
-            }
-          ]
+          "Name": "coordinates",
+          "Value": "/crs"
         }
       ]
     },
@@ -374,47 +373,48 @@
           "Name": "Data_Organization",
           "Value": "h5_trajectory"
         }
-      ],
-      "Applicability_Group": [
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "GEDI",
+        "ShortNamePath": "GEDI_L2B|GEDI02_B",
+        "Variable_Pattern": "/BEAM[\\d]+/pgap_theta_z"
+      },
+      "Attributes": [
         {
-          "Applicability": {
-            "ShortNamePath": "GEDI_L2B|GEDI02_B",
-            "Variable_Pattern": "/BEAM[\\d]+/pgap_theta_z"
-          },
-          "Attributes": [
-            {
-              "Name": "subset_control_variables",
-              "Value": "rx_sample_start_index, rx_sample_count"
-            },
-            {
-              "Name": "subset_control_type",
-              "Value": "fwd_segment_index"
-            }
-          ]
+          "Name": "subset_control_variables",
+          "Value": "rx_sample_start_index, rx_sample_count"
         },
         {
-          "Applicability": {
-            "ShortNamePath": "GEDI_L2B|GEDI02_B",
-            "Variable_Pattern": "/BEAM[\\d]+/rx_sample_start_index"
-          },
-          "Attributes": [
-            {
-              "Name": "subset_control_variable_type",
-              "Value": "segment_index_beg"
-            }
-          ]
-        },
+          "Name": "subset_control_type",
+          "Value": "fwd_segment_index"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "GEDI",
+        "ShortNamePath": "GEDI_L2B|GEDI02_B",
+        "Variable_Pattern": "/BEAM[\\d]+/rx_sample_start_index"
+      },
+      "Attributes": [
         {
-          "Applicability": {
-            "ShortNamePath": "GEDI_L2B|GEDI02_B",
-            "Variable_Pattern": "/BEAM[\\d]+/rx_sample_count"
-          },
-          "Attributes": [
-            {
-              "Name": "subset_control_variable_type",
-              "Value": "segment_index_cnt"
-            }
-          ]
+          "Name": "subset_control_variable_type",
+          "Value": "segment_index_beg"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "GEDI",
+        "ShortNamePath": "GEDI_L2B|GEDI02_B",
+        "Variable_Pattern": "/BEAM[\\d]+/rx_sample_count"
+      },
+      "Attributes": [
+        {
+          "Name": "subset_control_variable_type",
+          "Value": "segment_index_cnt"
         }
       ]
     }

--- a/config/CHANGELOG.md
+++ b/config/CHANGELOG.md
@@ -20,7 +20,9 @@ to simplify the schema for broader use.
   groups, not just the global attributes in an input file.
 * The `Applicability_Group` property within `CF_Overrides` and `CF_Supplements`
   has been removed. Now attributes should only be specified within the
-  `Attributes` property at the root level of an override or supplement.
+  `Attributes` property at the root level of an override or supplement. The
+  `Applicability` of a `CF_Override` or `CF_Supplement` must now include either
+  a `Mission` or a `ShortNamePath`.
 
 ## 0.0.1
 ### 2023-01-09

--- a/config/CHANGELOG.md
+++ b/config/CHANGELOG.md
@@ -18,6 +18,9 @@ to simplify the schema for broader use.
   `Applicability` part of the item, and including the updated attributes under
   the `Attributes` property of the item. This allows metadata overrides to all
   groups, not just the global attributes in an input file.
+* The `Applicability_Group` property within `CF_Overrides` and `CF_Supplements`
+  has been removed. Now attributes should only be specified within the
+  `Attributes` property at the root level of an override or supplement.
 
 ## 0.0.1
 ### 2023-01-09

--- a/tests/unit/data/test_config.json
+++ b/tests/unit/data/test_config.json
@@ -73,102 +73,96 @@
           "Name": "collection_override",
           "Value": "collection value"
         }
-      ],
-      "Applicability_Group": [
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "FakeSat",
+        "ShortNamePath": "FAKE99",
+        "Variable_Pattern": "/group/.*"
+      },
+      "Attributes": [
         {
-          "Applicability": {
-            "Variable_Pattern": "/group/.*"
-          },
-          "Attributes": [
-            {
-              "Name": "group_override",
-              "Value": "group value"
-            }
-          ]
-        },
-        {
-          "Applicability": {
-            "ShortNamePath": "FAKE99",
-            "Variable_Pattern": "/$"
-          },
-          "Attributes": [
-            {
-              "Name": "global_override",
-              "Value": "GLOBAL"
-            }
-          ]
-        },
-        {
-          "Applicability": {
-            "ShortNamePath": "FAKE99",
-            "Variable_Pattern": "/group/variable"
-          },
-          "Attributes": [
-            {
-              "Name": "variable_override",
-              "Value": "variable value"
-            }
-          ]
-        },
-        {
-          "Applicability": {
-            "Variable_Pattern": "/coordinates_group/.*"
-          },
-          "Attributes": [
-            {
-              "Name": "coordinates",
-              "Value": "lat, lon"
-            }
-          ]
-        },
-        {
-          "Applicability": {
-            "Variable_Pattern": "/absent_override"
-          },
-          "Attributes": [
-            {
-              "Name": "extra_override",
-              "Value": "overriding value"
-            }
-          ]
+          "Name": "group_override",
+          "Value": "group value"
         }
       ]
     },
     {
       "Applicability": {
         "Mission": "FakeSat",
-        "ShortNamePath": "FAKE98"
+        "ShortNamePath": "FAKE99",
+        "Variable_Pattern": "/$"
       },
-      "Applicability_Group": [
+      "Attributes": [
         {
-          "Applicability": {
-            "Variable_Pattern": "/group2/.*"
-          },
-          "Attributes": [
-            {
-              "Name": "other_collection",
-              "Value": "canopy_height"
-            }
-          ]
+          "Name": "global_override",
+          "Value": "GLOBAL"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "FakeSat",
+        "ShortNamePath": "FAKE99",
+        "Variable_Pattern": "/group/variable"
+      },
+      "Attributes": [
+        {
+          "Name": "variable_override",
+          "Value": "variable value"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "FakeSat",
+        "ShortNamePath": "FAKE99",
+        "Variable_Pattern": "/coordinates_group/.*"
+      },
+      "Attributes": [
+        {
+          "Name": "coordinates",
+          "Value": "lat, lon"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "FakeSat",
+        "ShortNamePath": "FAKE99",
+        "Variable_Pattern": "/absent_override"
+      },
+      "Attributes": [
+        {
+          "Name": "extra_override",
+          "Value": "overriding value"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "FakeSat",
+        "ShortNamePath": "FAKE98",
+        "Variable_Pattern": "/group2/.*"
+      },
+      "Attributes": [
+        {
+          "Name": "other_collection",
+          "Value": "canopy_height"
         }
       ]
     },
     {
       "Applicability": {
         "Mission": "FakeSat2",
-        "ShortNamePath": "FAKE99"
+        "ShortNamePath": "FAKE99",
+        "Variable_Pattern": "/group3/.*"
       },
-      "Applicability_Group": [
+      "Attributes": [
         {
-          "Applicability": {
-            "Variable_Pattern": "/group3/.*"
-          },
-          "Attributes": [
-            {
-              "Name": "other_mission",
-              "Value": "sea_surface_temperature"
-            }
-          ]
+          "Name": "other_mission",
+          "Value": "sea_surface_temperature"
         }
       ]
     }
@@ -184,52 +178,57 @@
           "Name": "collection_supplement",
           "Value": "FAKE99 supplement"
         }
-      ],
-      "Applicability_Group": [
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "FakeSat",
+        "ShortNamePath": "FAKE99",
+        "Variable_Pattern": "/group4/.*"
+      },
+      "Attributes": [
         {
-          "Applicability": {
-            "Variable_Pattern": "/group4/.*"
-          },
-          "Attributes": [
-            {
-              "Name": "group_supplement",
-              "Value": "FAKE99 group4"
-            }
-          ]
-        },
+          "Name": "group_supplement",
+          "Value": "FAKE99 group4"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "FakeSat",
+        "ShortNamePath": "FAKE99",
+        "Variable_Pattern": "/$"
+      },
+      "Attributes": [
         {
-          "Applicability": {
-            "ShortNamePath": "FAKE99",
-            "Variable_Pattern": "/$"
-          },
-          "Attributes": [
-            {
-              "Name": "fakesat_global_supplement",
-              "Value": "fakesat value"
-            }
-          ]
-        },
+          "Name": "fakesat_global_supplement",
+          "Value": "fakesat value"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "FakeSat",
+        "ShortNamePath": "FAKE99",
+        "Variable_Pattern": "/absent_override"
+      },
+      "Attributes": [
         {
-          "Applicability": {
-            "Variable_Pattern": "/absent_override"
-          },
-          "Attributes": [
-            {
-              "Name": "extra_override",
-              "Value": "supplemental value"
-            }
-          ]
-        },
+          "Name": "extra_override",
+          "Value": "supplemental value"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "FakeSat",
+        "ShortNamePath": "FAKE99",
+        "Variable_Pattern": "/absent_supplement"
+      },
+      "Attributes": [
         {
-          "Applicability": {
-            "Variable_Pattern": "/absent_supplement"
-          },
-          "Attributes": [
-            {
-              "Name": "extra_supplement",
-              "Value": "supplemental value"
-            }
-          ]
+          "Name": "extra_supplement",
+          "Value": "supplemental value"
         }
       ]
     }

--- a/varinfo/cf_config.py
+++ b/varinfo/cf_config.py
@@ -5,11 +5,10 @@
     CF-Convention attributes for a dataset, but can also be used to alter non
     CF-Convention metadata within a granule.
 
-    Information within the configuration file is split into blocks that have
-    an Applicability_Group. This section should define a mission, collection
-    short name and (optionally) a regular expression compatible string for
-    relevant variable paths. These applicability groups can be nested, and so
-    the mission and short name can be inherited from the parent group.
+    Information within the configuration file is split into rules that have
+    an Applicability. This section should define a mission, collection short
+    name and (optionally) a regular expression compatible string for relevant
+    variable paths.
 
     The configuration file also specifies variables that are incorrectly
     considered as science variables by the VarInfo class, due to them having
@@ -136,10 +135,7 @@ class CFConfig:
         for a variable pattern. This is indicative of there being
         overriding or supplemental attributes in this list item.
         Assign any information to the results dictionary, with a key of
-        that variable pattern. Lastly, check for any nested references,
-        which are child blocks to be processed in the same way. The mission
-        and short name from this block are passed to all children, as they
-        may not both be defined, due to assumed inheritance.
+        that variable pattern.
 
         """
         mission = cf_item['Applicability'].get('Mission') or input_mission
@@ -151,14 +147,7 @@ class CFConfig:
             # to all variables (see ICESat2 dimensions override, SPL4.* and
             # SPL3FTA grid_mapping overrides)
             pattern = cf_item['Applicability'].get('Variable_Pattern', '.*')
-
-            if 'Attributes' in cf_item:
-                results[pattern] = self._create_attributes_object(cf_item)
-
-            cf_references = cf_item.get('Applicability_Group', [])
-
-            for cf_reference in cf_references:
-                self._process_cf_item(cf_reference, results, mission, short_name)
+            results[pattern] = self._create_attributes_object(cf_item)
 
     @staticmethod
     def _create_attributes_object(cf_item: dict) -> dict[str, str]:


### PR DESCRIPTION
## Description

I promised the next PR or so would be shorter!

This PR flattens the rules in the `CF_Overrides` and `CF_Supplements` section of the configuration file scheme. Previously attributes being overridden could be specified either at the root level of a "rule" or in a nested `Applicability_Group` item. This PR removes that `Applicability_Group` item to reduce confusion in the schema. (This is probably one of the two biggest sources of confusion in the whole schema)

## Jira Issue ID

[TRT-554](https://bugs.earthdata.nasa.gov/browse/TRT-554)

## Local Test Steps

* Pull the branch locally.
* Run the tests - they should all pass.
* Pick a NetCDF-4 collection and grab a granule for it.
* Copy the sample configuration file (`config/1.0.0/sample_config.json`) and add some new rule to it to override a metadata attribute on either a variable or a group (or both!).
* Instantiate a `VarInfoFromNetCDF4` object for the NetCDF-4 file you have, using the configuration file from the previous step.
* Check the attributes on the appropriate variable. The override should have been applied.

Something like:
```
from varinfo import VarInfoFromNetCDF4

vi_instance = VarInfoFromNetCDF4('/file/path.nc4', short_name='SHORTNAME', config_file='/path/to/config_file.json')
print(vi_instance.get_variable('/path/to/variable/with/attribute').attributes)
print(vi_instance.groups['/path/to/group/with/attribute'].attributes)
```

## PR Acceptance Checklist
* [x] Jira ticket acceptance criteria met.
* [x] `CHANGELOG.md` updated to include high level summary of PR changes.
* ~~`VERSION` updated if publishing a release.~~
* [x] Tests ~~added/updated and~~ passing.
* [x] Documentation updated (if needed).
