### PR TITLE
TRT-555 remove CF_Supplements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ an input file.
 * `CFConfig.get_cf_attributes` has been renamed `CFConfig.get_cf_overrides`, as
   there are now only overrides to be returned from this method.
   `CFConfig.get_cf_overrides` now _must_ specify a variable path. All overrides
-  from a configuration file for a given collection is now retrievable from
+  from a configuration file for a given collection are now retrievable from
   the newly public `CFConfig.cf_overrides` class attribute.
 
 ### Removed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ an input file.
 * Handling of nested `Applicability_Groups` has been removed from the `CFConfig`
   class, as the configuration file no longer nests these items in overrides
   or supplements.
+* CF Overrides retrieved for a matching file path are ordered such that the
+  most specific applicable override to the variable takes precedence. For
+  example, when requesting the value of the "units" metadata attribute for
+  variable "/nested/variable", an applicability rule that exactly matches this
+  variable path will take precedence over rules matching to either the group,
+  or all variables in the file.
+* `CFConfig.get_cf_attributes` has been renamed `CFConfig.get_cf_overrides`, as
+  there are now only overrides to be returned from this method.
+  `CFConfig.get_cf_overrides` now _must_ specify a variable path. All overrides
+  from a configuration file for a given collection is now retrievable from
+  the newly public `CFConfig.cf_overrides` class attribute.
+
+### Removed:
+
+* `CFConfig._cf_supplements` has been deprecated in favour of specifying all
+  in-file metadata changes via a CF override instead.
 
 ## v2.3.0
 ### 2024-08-26

--- a/config/1.0.0/earthdata_varinfo_configuration_schema.json
+++ b/config/1.0.0/earthdata_varinfo_configuration_schema.json
@@ -298,11 +298,11 @@
           "type": "string"
         },
         "Applicability": {
-          "description": "An applicability rule that can be used to define global variables, if only a mission and/or collection short name is specified, or set variable and group level metadata attributes if a Variable_Pattern is provided.",
+          "description": "An applicability rule that indicates which groups and variables within a file a metadata override should apply to. If only a short name and/or mission is provided, the override will apply to all groups and variables. If a Variable_Pattern is also provided, the override is applied only to those groups or variables whose paths match the regular expression of the Variable_Pattern.",
           "$ref": "#/$defs/ApplicabilityType"
         },
         "Attributes" : {
-          "description": "Metadata attributes to overwrite against variables or groups matching a variable path pattern specified in Applicability of this object.",
+          "description": "Metadata attributes to override for variables or groups that match the mission, short name and/or Variable_Pattern criteria specified in the Applicability of this object.",
           "type": "array",
           "items": {
             "description": "A list of metadata attributes with their names and values.",

--- a/config/1.0.0/earthdata_varinfo_configuration_schema.json
+++ b/config/1.0.0/earthdata_varinfo_configuration_schema.json
@@ -30,7 +30,7 @@
       }
     },
     "Excluded_Science_Variables": {
-      "description": "If CF_Overrides are not enough VarInfo classes will assume certain variables are science variables. This setting provides variable path patterns that should be excluded from consideration as a science variable.",
+      "description": "VarInfo classes currently assume that any variable that has a grid mapping attribute, or has a spatial or temporal dimension and is not itself a dimension or bounds variable, should be treated as a science variable. This may not be true in all cases, and so Excluded_Science_Variables provide a method to denote non-science variables that might otherwise be incorrectly identified.",
       "type": "array",
       "items": {
         "$ref": "#/$defs/MissionVariablePatternType"
@@ -232,7 +232,7 @@
           "type": "string"
         },
         "Value": {
-          "description": "The metadata attribute value. This will replace any value present.",
+          "description": "The overriding metadata attribute value. The value specified in the configuration file will replace the corresponding metadata value in any applicable source file.",
           "anyOf": [{
             "type": ["number", "string"]
           }, {

--- a/config/1.0.0/earthdata_varinfo_configuration_schema.json
+++ b/config/1.0.0/earthdata_varinfo_configuration_schema.json
@@ -294,7 +294,7 @@
       "type": "object",
       "properties": {
         "_Description": {
-          "description": "A description of the need for and effect of the overrides.",
+          "description": "Explains the purpose and effect of these overrides.",
           "type": "string"
         },
         "Applicability": {

--- a/config/1.0.0/earthdata_varinfo_configuration_schema.json
+++ b/config/1.0.0/earthdata_varinfo_configuration_schema.json
@@ -30,7 +30,7 @@
       }
     },
     "Excluded_Science_Variables": {
-      "description": "If CF_Overrides and CF_Supplements are not enough VarInfo classes will assume certain variables are science variables. This setting provides variable path patterns that should be excluded from consideration as a science variable.",
+      "description": "If CF_Overrides are not enough VarInfo classes will assume certain variables are science variables. This setting provides variable path patterns that should be excluded from consideration as a science variable.",
       "type": "array",
       "items": {
         "$ref": "#/$defs/MissionVariablePatternType"
@@ -193,14 +193,7 @@
       "description": "# For cases where CF references do not exist, or are invalid. For example, variables that have no dimension references in the HDF-5 file contents",
       "type": "array",
       "items": {
-        "$ref": "#/$defs/CFOverridesAndSupplementsItemType"
-      }
-    },
-    "CF_Supplements": {
-      "description": "For extending CF references. This allows for CF references to persist, while supplemental information is provided. In particular, e.g., for subsetting support, non-CF attributes can be provided.",
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/CFOverridesAndSupplementsItemType"
+        "$ref": "#/$defs/CFOverridesItemType"
       }
     }
   },
@@ -239,7 +232,7 @@
           "type": "string"
         },
         "Value": {
-          "description": "The metadata attribute value. For CFOverrides, this will replace any value present, for CFSupplements, this is expected to be a string and it will be appended to the present value using string concatenation.",
+          "description": "The metadata attribute value. This will replace any value present.",
           "anyOf": [{
             "type": ["number", "string"]
           }, {
@@ -296,20 +289,20 @@
       "required": ["Applicability", "Variable_Pattern"],
       "additionalProperties": false
     },
-    "CFOverridesAndSupplementsItemType": {
-      "description": "An item that details a related group of CF-Convention metadata attributes to supplement or overwrite according to the supplied applicability rules.",
+    "CFOverridesItemType": {
+      "description": "An item that details one or more metadata attributes to overwrite according to the supplied applicability rules.",
       "type": "object",
       "properties": {
         "_Description": {
-          "description": "A description of the need for and effect of the CF Convention overrides or supplements.",
+          "description": "A description of the need for and effect of the overrides.",
           "type": "string"
         },
         "Applicability": {
-          "description": "An applicability rule that can be used to define global variables, if only a mission and/or collection short name is specified, or set variable metadata attributes if a Variable_Pattern is provided.",
+          "description": "An applicability rule that can be used to define global variables, if only a mission and/or collection short name is specified, or set variable and group level metadata attributes if a Variable_Pattern is provided.",
           "$ref": "#/$defs/ApplicabilityType"
         },
         "Attributes" : {
-          "description": "Metadata attributes to supplement or overwrite against variables matching a variable path pattern specified in Applicability of this object.",
+          "description": "Metadata attributes to overwrite against variables or groups matching a variable path pattern specified in Applicability of this object.",
           "type": "array",
           "items": {
             "description": "A list of metadata attributes with their names and values.",

--- a/config/1.0.0/sample_config_1.0.0.json
+++ b/config/1.0.0/sample_config_1.0.0.json
@@ -140,6 +140,19 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3SMP_E",
+        "Variable_Pattern": "/$"
+      },
+      "Attributes": [
+        {
+          "Name": "Data_Organization",
+          "Value": "h5_grid"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SMP_E",
         "Variable_Pattern": "/Soil_Moisture_Retrieval_Data_AM/.*"
       },
       "Attributes": [
@@ -178,9 +191,7 @@
           "Value": "../../grid_x ../../grid_y"
         }
       ]
-    }
-  ],
-  "CF_Supplements": [
+    },
     {
       "Applicability": {
         "Mission": "ICESat2",
@@ -346,19 +357,6 @@
         {
           "Name": "coordinates",
           "Value": "/crs"
-        }
-      ]
-    },
-    {
-      "Applicability": {
-        "Mission": "SMAP",
-        "ShortNamePath": "SPL3SMP_E",
-        "Variable_Pattern": "/$"
-      },
-      "Attributes": [
-        {
-          "Name": "Data_Organization",
-          "Value": "h5_grid"
         }
       ]
     },

--- a/config/CHANGELOG.md
+++ b/config/CHANGELOG.md
@@ -25,7 +25,7 @@ to simplify the schema for broader use.
   a `Mission` or a `ShortNamePath`.
 * The `CF_Supplements` section of the `CFOverridesOrSupplementItemType` has
   been removed, and the item type renamed to `CFOverridesItemType`. All changes
-  to in-file metadata attributes should now be specified as a `CF_Override`.
+  to in-file metadata attributes should now be specified in `CF_Overrides`.
 
 ## 0.0.1
 ### 2023-01-09

--- a/config/CHANGELOG.md
+++ b/config/CHANGELOG.md
@@ -23,6 +23,9 @@ to simplify the schema for broader use.
   `Attributes` property at the root level of an override or supplement. The
   `Applicability` of a `CF_Override` or `CF_Supplement` must now include either
   a `Mission` or a `ShortNamePath`.
+* The `CF_Supplements` section of the `CFOverridesOrSupplementItemType` has
+  been removed, and the item type renamed to `CFOverridesItemType`. All changes
+  to in-file metadata attributes should now be specified as a `CF_Override`.
 
 ## 0.0.1
 ### 2023-01-09

--- a/docs/earthdata-varinfo.ipynb
+++ b/docs/earthdata-varinfo.ipynb
@@ -26,7 +26,7 @@
     "* Parses and extracts variable metadata from within source granules.\n",
     "* Also parses relationships between variables, primarily using dimension information or CF-Convention attributes expected to contain such information.\n",
     "* Variable classification via CF-Convention-based heuristics (e.g., using `units` and other attributes).\n",
-    "* Metadata can be supplemented or overwritten with a configuration file (which has a fully defined JSON schema).\n",
+    "* Metadata can be overwritten with a configuration file (which has a fully defined JSON schema).\n",
     "* Extensible for further input formats (uses abstract base classes).\n",
     "* Common Metadata Repository ([CMR](https://www.earthdata.nasa.gov/eosdis/science-system-description/eosdis-components/cmr)) compliant UMM-Var JSON generation.\n",
     "\n",

--- a/tests/unit/data/test_config.json
+++ b/tests/unit/data/test_config.json
@@ -208,6 +208,58 @@
           "Value": "applies to /group/variable"
         }
       ]
+    },
+    {
+      "Applicability": {
+        "Mission": "FakeSat",
+        "ShortNamePath": "FAKE97",
+        "Variable_Pattern": "/other_group/variable"
+      },
+      "Attributes": [
+        {
+          "Name": "test_depth_priority_over_string_length",
+          "Value": "applies to /other_group/variable"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "FakeSat",
+        "ShortNamePath": "FAKE97",
+        "Variable_Pattern": "/(other_group|long|regex|things).*"
+      },
+      "Attributes": [
+        {
+          "Name": "test_depth_priority_over_string_length",
+          "Value": "applies to lots of groups"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "FakeSat",
+        "ShortNamePath": "FAKE97",
+        "Variable_Pattern": "/string_length/variable"
+      },
+      "Attributes": [
+        {
+          "Name": "test_string_length_same_depth",
+          "Value": "applies to /string_length/variable"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "FakeSat",
+        "ShortNamePath": "FAKE97",
+        "Variable_Pattern": "/string_length/var.*"
+      },
+      "Attributes": [
+        {
+          "Name": "test_string_length_same_depth",
+          "Value": "applies to /string_length/var.*"
+        }
+      ]
     }
   ]
 }

--- a/tests/unit/data/test_config.json
+++ b/tests/unit/data/test_config.json
@@ -165,70 +165,47 @@
           "Value": "sea_surface_temperature"
         }
       ]
-    }
-  ],
-  "CF_Supplements": [
+    },
     {
       "Applicability": {
         "Mission": "FakeSat",
-        "ShortNamePath": "FAKE99"
+        "ShortNamePath": "FAKE97",
+        "Variable_Pattern": "/.*"
       },
       "Attributes": [
         {
-          "Name": "collection_supplement",
-          "Value": "FAKE99 supplement"
+          "Name": "conflicting_attribute_global_and_group",
+          "Value": "applies to all"
         }
       ]
     },
     {
       "Applicability": {
         "Mission": "FakeSat",
-        "ShortNamePath": "FAKE99",
-        "Variable_Pattern": "/group4/.*"
+        "ShortNamePath": "FAKE97",
+        "Variable_Pattern": "/group/.*"
       },
       "Attributes": [
         {
-          "Name": "group_supplement",
-          "Value": "FAKE99 group4"
+          "Name": "conflicting_attribute_global_and_group",
+          "Value": "applies to /group/.*"
+        },
+        {
+          "Name": "conflicting_attribute_group_and_variable",
+          "Value": "applies to /group/.*"
         }
       ]
     },
     {
       "Applicability": {
         "Mission": "FakeSat",
-        "ShortNamePath": "FAKE99",
-        "Variable_Pattern": "/$"
+        "ShortNamePath": "FAKE97",
+        "Variable_Pattern": "/group/variable"
       },
       "Attributes": [
         {
-          "Name": "fakesat_global_supplement",
-          "Value": "fakesat value"
-        }
-      ]
-    },
-    {
-      "Applicability": {
-        "Mission": "FakeSat",
-        "ShortNamePath": "FAKE99",
-        "Variable_Pattern": "/absent_variable"
-      },
-      "Attributes": [
-        {
-          "Name": "extra_override",
-          "Value": "supplemental value"
-        }
-      ]
-    },
-    {
-      "Applicability": {
-        "Mission": "FakeSat",
-        "ShortNamePath": "FAKE99",
-        "Variable_Pattern": "/absent_supplement"
-      },
-      "Attributes": [
-        {
-          "Name": "extra_supplement",
-          "Value": "supplemental value"
+          "Name": "conflicting_attribute_group_and_variable",
+          "Value": "applies to /group/variable"
         }
       ]
     }

--- a/tests/unit/test_attribute_container.py
+++ b/tests/unit/test_attribute_container.py
@@ -48,7 +48,6 @@ class TestAttributeContainerFromDmr(TestCase):
         """Ensure an `AttributeContainerFromDmr` can be created from a group."""
         expected_attributes = {
             'collection_override': 'collection value',
-            'collection_supplement': 'FAKE99 supplement',
             'coordinates': 'lat_for_group lon_for_group',
         }
 
@@ -70,7 +69,6 @@ class TestAttributeContainerFromDmr(TestCase):
         """Ensure an `AttributeContainerFromDmr` can be created from a variable."""
         expected_attributes = {
             'collection_override': 'collection value',
-            'collection_supplement': 'FAKE99 supplement',
             'group_override': 'group value',
             'units': 'm',
             'variable_override': 'variable value',
@@ -145,8 +143,6 @@ class TestAttributeContainerFromNetCDF4(TestCase):
         netcdf4_path = write_skeleton_netcdf4(self.output_dir)
         expected_attributes = {
             'collection_override': 'collection value',
-            'collection_supplement': 'FAKE99 supplement',
-            'fakesat_global_supplement': 'fakesat value',
             'global_override': 'GLOBAL',
             **netcdf4_global_attributes,
         }
@@ -174,7 +170,6 @@ class TestAttributeContainerFromNetCDF4(TestCase):
         netcdf4_path = write_skeleton_netcdf4(self.output_dir)
         expected_attributes = {
             'collection_override': 'collection value',
-            'collection_supplement': 'FAKE99 supplement',
         }
 
         with Dataset(netcdf4_path) as dataset:
@@ -200,7 +195,6 @@ class TestAttributeContainerFromNetCDF4(TestCase):
         netcdf4_path = write_skeleton_netcdf4(self.output_dir)
         expected_attributes = {
             'collection_override': 'collection value',
-            'collection_supplement': 'FAKE99 supplement',
             'coordinates': '/lat /lon',
             'description': 'A science variable for testing',
             'group_override': 'group value',

--- a/tests/unit/test_cf_config.py
+++ b/tests/unit/test_cf_config.py
@@ -35,13 +35,6 @@ class TestCFConfig(TestCase):
             '/group/.*': {'group_override': 'group value'},
             '/group/variable': {'variable_override': 'variable value'},
         }
-        cls.expected_cf_supplements = {
-            '.*': {'collection_supplement': 'FAKE99 supplement'},
-            '/$': {'fakesat_global_supplement': 'fakesat value'},
-            '/absent_variable': {'extra_override': 'supplemental value'},
-            '/absent_supplement': {'extra_supplement': 'supplemental value'},
-            '/group4/.*': {'group_supplement': 'FAKE99 group4'},
-        }
 
     def test_instantiation(self):
         """Ensure the attributes of an object are set upon class
@@ -61,15 +54,7 @@ class TestCFConfig(TestCase):
         )
 
         self.assertSetEqual(self.required_variables, config.required_variables)
-
-        # The attributes below are protected-access within the class, however,
-        # this test should still check they only contain the expected items.
-        self.assertEqual(
-            self.expected_cf_overrides, config._cf_overrides
-        )  # pylint: disable=W0212
-        self.assertEqual(
-            self.expected_cf_supplements, config._cf_supplements
-        )  # pylint: disable=W0212
+        self.assertDictEqual(self.expected_cf_overrides, config.cf_overrides)
 
     def test_instantiation_no_file(self):
         """Ensure an instance of the `CFConfig` class can be produced when no
@@ -82,6 +67,7 @@ class TestCFConfig(TestCase):
         self.assertEqual(self.short_name, config.short_name)
         self.assertSetEqual(set(), config.excluded_science_variables)
         self.assertSetEqual(set(), config.required_variables)
+        self.assertDictEqual({}, config.cf_overrides)
 
     def test_instantiation_missing_configuration_file(self):
         """Ensure a MissingConfigurationFileError is raised when a path to a
@@ -103,27 +89,12 @@ class TestCFConfig(TestCase):
                 config_file='tests/unit/data/ATL03_example.dmr',
             )
 
-    def test_get_cf_attributes_all(self):
-        """Ensure the CFConfig.get_cf_references method returns all the
-        overriding and supplemental references from the class, in
-        dictionaries that are keyed on the variable pattern.
-
-        """
-        config = CFConfig(self.mission, self.short_name, self.test_config)
-        self.assertDictEqual(
-            config.get_cf_attributes(),
-            {
-                'cf_overrides': self.expected_cf_overrides,
-                'cf_supplements': self.expected_cf_supplements,
-            },
-        )
-
-    def test_get_cf_attributes_variable(self):
-        """Ensure the CFConfig.get_cf_references method returns all overriding
-        and supplemental attributes where the variable pattern matches the
-        supplied variable name. If multiple patterns match the variable
-        name, then all attributes from those patterns should be combined
-        into a single output dictionary.
+    def test_get_cf_overrides_variable(self):
+        """Ensure the CFConfig.get_cf_overrides method returns all overriding
+        attributes where the variable pattern matches the supplied variable or
+        group name. If multiple patterns match the variable name, then all
+        attributes from those patterns should be combined into a single output
+        dictionary.
 
         """
         collection_overrides = {'collection_override': 'collection value'}
@@ -137,44 +108,45 @@ class TestCFConfig(TestCase):
             'variable_override': 'variable value',
         }
 
-        collection_supplements = {'collection_supplement': 'FAKE99 supplement'}
-        group4_supplements = {
-            'collection_supplement': 'FAKE99 supplement',
-            'group_supplement': 'FAKE99 group4',
-        }
-
         test_args = [
             [
                 'Collection only',
                 'random_variable',
                 collection_overrides,
-                collection_supplements,
             ],
             [
                 'Group overrides',
                 '/group/random',
                 group_overrides,
-                collection_supplements,
             ],
             [
                 'Variable overrides',
                 '/group/variable',
                 variable_overrides,
-                collection_supplements,
-            ],
-            [
-                'Group supplements',
-                '/group4/variable',
-                collection_overrides,
-                group4_supplements,
             ],
         ]
 
         config = CFConfig(self.mission, self.short_name, self.test_config)
 
-        for description, variable, overrides, supplements in test_args:
+        for description, variable, overrides in test_args:
             with self.subTest(description):
                 self.assertDictEqual(
-                    config.get_cf_attributes(variable),
-                    {'cf_overrides': overrides, 'cf_supplements': supplements},
+                    config.get_cf_overrides(variable),
+                    overrides,
                 )
+
+    def test_get_cf_overrides_variable_conflicts(self):
+        """Ensure that if a variable matches multiple override rules that
+        specify conflicting values for a metadata attribute, the most specific
+        matching metadata attribute takes precedence.
+
+        """
+        config = CFConfig(self.mission, 'FAKE97', self.test_config)
+
+        self.assertDictEqual(
+            config.get_cf_overrides('/group/variable'),
+            {
+                'conflicting_attribute_global_and_group': 'applies to /group/.*',
+                'conflicting_attribute_group_and_variable': 'applies to /group/variable',
+            },
+        )

--- a/tests/unit/test_cf_config.py
+++ b/tests/unit/test_cf_config.py
@@ -142,7 +142,9 @@ class TestCFConfig(TestCase):
         matching metadata attribute takes precedence.
 
         The primary measure of specificity is the depth of the variable
-        hierarchy specified in the
+        hierarchy specified in the Variable_Pattern, with secondary sorting
+        based upon the length of strings at the same hierarchy.
+
         """
         config = CFConfig(self.mission, 'FAKE97', self.test_config)
 

--- a/tests/unit/test_group.py
+++ b/tests/unit/test_group.py
@@ -45,10 +45,9 @@ class TestGroupFromDmr(TestCase):
         Child variables should be listed via the `variables` class attribute.
 
         """
-        # First two attributes come from CFConfig.
+        # First attribute comes from CFConfig, the second from the DMR.
         expected_attributes = {
             'collection_override': 'collection value',
-            'collection_supplement': 'FAKE99 supplement',
             'coordinates': 'lat lon',
         }
 
@@ -96,8 +95,6 @@ class TestGroupFromNetCDF4(TestCase):
         """Ensure a group can be created from an input NetCDF-4 file."""
         expected_attributes = {
             'collection_override': 'collection value',
-            'collection_supplement': 'FAKE99 supplement',
-            'fakesat_global_supplement': 'fakesat value',
             'global_override': 'GLOBAL',
             **netcdf4_global_attributes,
         }

--- a/tests/unit/test_var_info.py
+++ b/tests/unit/test_var_info.py
@@ -250,7 +250,7 @@ class TestVarInfoFromDmr(TestCase):
         """Ensure VarInfo instantiates correctly, creating records of all the
         variables in the granule, and correctly deciding if they are
         science variables, metadata or references. This test uses a mission
-        and short name that do not have any CF overrides or supplements.
+        and short name that do not have any CF overrides.
 
         """
         dataset = VarInfoFromDmr(self.mock_geographic_dmr, config_file=self.config_file)
@@ -297,16 +297,14 @@ class TestVarInfoFromDmr(TestCase):
 
     def test_var_info_instantiation_cf_augmentation(self):
         """Ensure VarInfo instantiates correcly, using a missions that has
-        overrides and supplements in the CFConfig class.
+        overrides in the CFConfig class.
 
         """
         dataset = VarInfoFromDmr(self.mock_dmr_two, config_file=self.config_file)
 
         expected_global_attributes = {
             'collection_override': 'collection value',
-            'collection_supplement': 'FAKE99 supplement',
             'global_override': 'GLOBAL',
-            'fakesat_global_supplement': 'fakesat value',
         }
 
         self.assertSetEqual(
@@ -330,7 +328,6 @@ class TestVarInfoFromDmr(TestCase):
             dataset.groups['/METADATA/DatasetIdentification'].attributes,
             {
                 'collection_override': 'collection value',
-                'collection_supplement': 'FAKE99 supplement',
                 'shortName': 'FAKE99',
             },
         )
@@ -922,7 +919,6 @@ class TestVarInfoFromDmr(TestCase):
             self.assertDictEqual(
                 dataset.get_missing_variable_attributes('/absent_variable'),
                 {
-                    'collection_supplement': 'FAKE99 supplement',
                     'collection_override': 'collection value',
                     'extra_override': 'overriding value',
                 },

--- a/tests/unit/test_variable.py
+++ b/tests/unit/test_variable.py
@@ -131,9 +131,8 @@ class TestVariableFromDmr(TestCase):
         they are contained in the variable XML, to ensure data requests
         can be made against the variable with index ranges specified.
 
-        Any applicable attribute override or supplement for an absent
-        metadata attribute should also be adopted as the value for that
-        attribute, with overrides taking precedence over supplements.
+        Any applicable attribute override for an absent or incorrect metadata
+        attribute should also be adopted as the value for that attribute.
 
         """
         variable = VariableFromDmr(
@@ -154,7 +153,6 @@ class TestVariableFromDmr(TestCase):
                 'subset_control_variables',
                 'units',
                 'collection_override',
-                'collection_supplement',
                 'group_override',
                 'variable_override',
             },
@@ -231,28 +229,10 @@ class TestVariableFromDmr(TestCase):
             variable.attributes.get('collection_override'), 'collection value'
         )
 
-    def test_variable_cf_supplement_non_reference(self):
-        """Ensure a metadata attribute is supplemented by the `CFConfig`."""
-        dmr_variable = ET.fromstring(
-            f'<{self.namespace}Float64 name="science">'
-            f'  <{self.namespace}Attribute name="group_supplement" type="String">'
-            f'    <{self.namespace}Value>initial_value</{self.namespace}Value>'
-            f'  </{self.namespace}Attribute>'
-            f'</{self.namespace}Float64>'
-        )
-
-        variable = VariableFromDmr(
-            dmr_variable, self.fakesat_config, self.namespace, '/group4/science'
-        )
-
-        self.assertEqual(
-            variable.attributes.get('group_supplement'), 'initial_value, FAKE99 group4'
-        )
-
     def test_variable_cf_override_absent(self):
         """Ensure a metadata attribute adopts the override value, even if the
         granule metadata originally omitted that attribute. The overriding
-        value should be used, and any supplemental value should be ignored.
+        value should be used.
 
         """
         dmr_variable = ET.fromstring(
@@ -265,24 +245,6 @@ class TestVariableFromDmr(TestCase):
         )
 
         self.assertEqual(variable.attributes.get('extra_override'), 'overriding value')
-
-    def test_variable_cf_supplement_absent(self):
-        """Ensure a metadata attribute adopts the override value, even if the
-        granule metadata originally omitted that attribute.
-
-        """
-        dmr_variable = ET.fromstring(
-            f'<{self.namespace}Float64 name="absent_supplement">'
-            f'</{self.namespace}Float64>'
-        )
-
-        variable = VariableFromDmr(
-            dmr_variable, self.fakesat_config, self.namespace, '/absent_supplement'
-        )
-
-        self.assertEqual(
-            variable.attributes.get('extra_supplement'), 'supplemental value'
-        )
 
     def test_variable_reference_qualification(self):
         """Ensure different reference types (relative, absolute) are correctly
@@ -761,7 +723,6 @@ class TestVariableFromDmr(TestCase):
                 'valid_max',
                 'scale',
                 'collection_override',
-                'collection_supplement',
             },
         )
         self.assertEqual(variable.attributes['units'], 'metres')

--- a/varinfo/attribute_container.py
+++ b/varinfo/attribute_container.py
@@ -99,14 +99,7 @@ class AttributeContainerBase(ABC):
         value.
 
         """
-        cf_override = self.cf_overrides.get(attribute_name)
-
-        if cf_override is not None:
-            attribute_value = cf_override
-        else:
-            attribute_value = raw_attribute_value
-
-        return attribute_value
+        return self.cf_overrides.get(attribute_name, raw_attribute_value)
 
 
 class AttributeContainerFromDmr(AttributeContainerBase):

--- a/varinfo/attribute_container.py
+++ b/varinfo/attribute_container.py
@@ -40,7 +40,7 @@ class AttributeContainerBase(ABC):
         """
         self.namespace = namespace
         self.full_name_path = full_name_path
-        self.cf_config = cf_config.get_cf_attributes(self.full_name_path)
+        self.cf_overrides = cf_config.get_cf_overrides(self.full_name_path)
         self.attributes = self._get_attributes(container)
         self._add_additional_attributes()
 
@@ -78,8 +78,7 @@ class AttributeContainerBase(ABC):
         be added to the variable metadata attributes.
 
         """
-        self._add_missing_attributes(self.cf_config['cf_overrides'])
-        self._add_missing_attributes(self.cf_config['cf_supplements'])
+        self._add_missing_attributes(self.cf_overrides)
 
     def _add_missing_attributes(self, extra_attributes: dict) -> None:
         """Iterate through a dictionary of attributes from the `CFConfig`
@@ -100,18 +99,12 @@ class AttributeContainerBase(ABC):
         value.
 
         """
-        cf_override = self.cf_config['cf_overrides'].get(attribute_name)
-        cf_supplement = self.cf_config['cf_supplements'].get(attribute_name)
+        cf_override = self.cf_overrides.get(attribute_name)
 
         if cf_override is not None:
             attribute_value = cf_override
         else:
             attribute_value = raw_attribute_value
-
-        if cf_supplement is not None and attribute_value is not None:
-            attribute_value = ', '.join([attribute_value, cf_supplement])
-        elif cf_supplement is not None:
-            attribute_value = cf_supplement
 
         return attribute_value
 

--- a/varinfo/cf_config.py
+++ b/varinfo/cf_config.py
@@ -1,9 +1,9 @@
 """ This module contains a class designed to read and present information from
-    a JSON configuration file. This configuration file provides supplemental
-    and overriding information for attributes provided by granules on a per-
-    collection basis. This information is primarily intended to augment the
-    CF-Convention attributes for a dataset, but can also be used to alter non
-    CF-Convention metadata within a granule.
+    a JSON configuration file. This configuration file provides overriding
+    information for attributes provided by granules on a per-collection basis.
+    This information is primarily intended to augment the CF-Convention
+    attributes for a dataset, but can also be used to alter non CF-Convention
+    metadata within a granule.
 
     Information within the configuration file is split into rules that have
     an Applicability. This section should define a mission, collection short
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 from os.path import exists
+from typing import Any
 import json
 import re
 
@@ -32,9 +33,8 @@ from varinfo.exceptions import (
 
 class CFConfig:
     """This class should read the main configuration file,
-    see e.g. sample_config.json, which defines overriding values and
-    supplements for the attributes stored in fields such as
-    ancillary_variables, or dimensions.
+    see e.g. sample_config.json, which defines overriding values for the
+    attributes stored in fields such as ancillary_variables, or dimensions.
 
     Given a mission and collection short name, upon instantiation, the
     object should only retain information relevant to that specific
@@ -57,8 +57,7 @@ class CFConfig:
         self.mission = mission
         self.short_name = collection_short_name
 
-        self._cf_overrides: dict = {}
-        self._cf_supplements: dict = {}
+        self.cf_overrides: dict[str, dict[str, Any]] = {}
         self.excluded_science_variables: set[str] = set()
         self.required_variables: set[str] = set()
 
@@ -102,10 +101,7 @@ class CFConfig:
         }
 
         for override in config.get('CF_Overrides', []):
-            self._process_cf_item(override, self._cf_overrides)
-
-        for supplement in config.get('CF_Supplements', []):
-            self._process_cf_item(supplement, self._cf_supplements)
+            self._process_cf_item(override, self.cf_overrides)
 
     def _is_applicable(self, mission: str, short_name: str | None = None) -> bool:
         """Given a mission, and optionally also a collection short name, of an
@@ -129,13 +125,12 @@ class CFConfig:
         input_mission: str | None = None,
         input_short_name: str | None = None,
     ):
-        """Process a single block in the CF overrides or CF supplements region
-        of the configuration file. First check that the applicability
-        matches the mission and short name for the class. Next, check
-        for a variable pattern. This is indicative of there being
-        overriding or supplemental attributes in this list item.
-        Assign any information to the results dictionary, with a key of
-        that variable pattern.
+        """Process a single block in the CF overrides region of the
+        configuration file. First check that the applicability matches the
+        mission and short name for the class. Next, check for a variable
+        pattern. This is indicative of there being overriding attributes in
+        this list item. Assign any information to the results dictionary, with
+        a key of that variable pattern.
 
         """
         mission = cf_item['Applicability'].get('Mission') or input_mission
@@ -160,40 +155,43 @@ class CFConfig:
             for attribute in cf_item.get('Attributes', {})
         }
 
-    def get_cf_attributes(
-        self, variable: str | None = None
-    ) -> dict[str, dict[str, str]]:
-        """Return the CF overrides and supplements that match a given
-        variable. If a variable is not specified, then return all overrides
-        and supplements. If there are no overrides or supplements, then
-        empty dictionaries will be returned instead.
+    def get_cf_overrides(self, variable_path: str) -> dict[str, Any]:
+        """Return the CF overrides that match a given variable. If there are no
+        overrides, then empty dictionaries will be returned instead.
+
+        First iterate through the self.cf_overrides and find all items with a
+        variable pattern that matches the supplied variable (or group) path.
+
+        Next sort that dictionary, so that variable pattern keys are ordered
+        from the shortest (more generic) to longest (more specific).
+
+        Last, combine the attribute names and values from each matching
+        override item. Because of the ordering in the previous step, if there
+        are multiple values supplied for the same metadata attribute, the value
+        retained will be the one with the longest variable pattern, which is a
+        proxy for how specific the override is.
 
         """
-        if variable is not None:
-            cf_overrides = self._get_matching_attributes(self._cf_overrides, variable)
-            cf_supplements = self._get_matching_attributes(
-                self._cf_supplements, variable
-            )
-        else:
-            cf_overrides = self._cf_overrides
-            cf_supplements = self._cf_supplements
+        matching_overrides = {
+            pattern: attributes
+            for pattern, attributes in self.cf_overrides.items()
+            if re.match(pattern, variable_path) is not None
+        }
 
-        return {'cf_overrides': cf_overrides, 'cf_supplements': cf_supplements}
+        # Order override items by the length of the variable pattern, from
+        # shortest to longest.
+        sorted_overrides = dict(
+            sorted(
+                matching_overrides.items(),
+                key=lambda pattern: len(pattern[0]),
+            ),
+        )
 
-    @staticmethod
-    def _get_matching_attributes(
-        cf_references: dict[str, dict[str, str]], variable: str
-    ) -> dict[str, str]:
-        """Iterate through either the self._cf_supplements or
-        self._cf_overrides and extract a dictionary that combines all
-        applicable attributes that apply to the specified variable. If
-        there are conflicting values for the same attribute, only the last
-        value will be returned for that attribute.
-
-        """
-        references = {}
-        for pattern, attributes in cf_references.items():
-            if re.match(pattern, variable) is not None:
-                references.update(attributes)
-
-        return references
+        # Combine all overrides. In case of multiple overrides for the same
+        # metadata attribute, the value that comes later based on the ordering
+        # of variable patterns will be used.
+        return {
+            attribute_name: attribute_value
+            for sorted_override in sorted_overrides.values()
+            for attribute_name, attribute_value in sorted_override.items()
+        }

--- a/varinfo/var_info.py
+++ b/varinfo/var_info.py
@@ -344,10 +344,7 @@ class VarInfoBase(ABC):
         variables would need to be in the configuration file.
 
         """
-        variable_attributes = self.cf_config.get_cf_attributes(variable_name)
-        return (
-            variable_attributes['cf_supplements'] | variable_attributes['cf_overrides']
-        )
+        return self.cf_config.get_cf_overrides(variable_name)
 
     def get_references_for_attribute(
         self, list_of_variables: list[str], reference_attribute_name: str

--- a/varinfo/variable.py
+++ b/varinfo/variable.py
@@ -28,8 +28,8 @@ InputVariableType = Union[ET.Element, NetCDF4Variable]
 class VariableBase(AttributeContainerBase):
     """A class to represent a single variable contained within a granule
     representation. It will produce an object in which references are
-    fully qualified, and also augmented by any overrides or supplements
-    from the supplied configuration file.
+    fully qualified, and also augmented by any overrides from the supplied
+    configuration file.
 
     """
 
@@ -242,27 +242,22 @@ class VariableBase(AttributeContainerBase):
 
     def _extract_dimensions(self, variable: ET.Element) -> list[str]:
         """Find the dimensions for the variable in question. If there are
-        overriding or supplemental dimensions from the CF configuration
-        file, these are used instead of, or in addition to, the raw
-        dimensions from the `.dmr`. All references are converted to
-        absolute paths in the granule. A set of all fully qualified
-        references is returned.
+        overriding dimensions from the `earthdata-varinfo` configuration
+        file, these are used instead of the raw dimensions from the `.dmr`. All
+        references are converted to absolute paths in the granule. A set of all
+        fully qualified references is returned.
 
         """
-        overrides = self.cf_config['cf_overrides'].get('dimensions')
-        supplements = self.cf_config['cf_supplements'].get('dimensions')
+        dimensions_override = self.cf_overrides.get('dimensions')
 
-        if overrides is not None:
-            dimensions = re.split(r'\s+|,\s*', overrides)
+        if dimensions_override is not None:
+            dimensions = re.split(r'\s+|,\s*', dimensions_override)
         else:
             dimensions = [
                 dimension
                 for dimension in self._get_raw_dimensions(variable)
                 if dimension is not None
             ]
-
-        if supplements is not None:
-            dimensions += re.split(r'\s+|,\s*', supplements)
 
         return self._qualify_references(dimensions)
 


### PR DESCRIPTION
## Description

This PR fulfils the next step in simplifying the `earthdata-varinfo` configuration file schema by removing the `CF_Supplements` section, in favour of all rules there being specified as `CF_Overrides`. This is Proposal 3 in [the list of proposed schema changes](https://wiki.earthdata.nasa.gov/display/SITC/earthdata-varinfo+configuration+schema+v2.0.0+proposal). The linked wiki page also includes details on specific rules in use right now. At the time of compilation, there were no supplements that could not be expressed as overrides.

Two, more in the weeds changes:

* There's a bit of a change in the `CFConfig` public methods and attributes. I'll highlight that in the appropriate place.
* I noticed there wasn't any way in which precedence was given to conflicting overrides that specify values for the same metadata attributes. This PR implements logic to ensure the most specific override for a given variable takes precedence. (The proxy for specificity is the length of the `Variable_Pattern`)

## Jira Issue ID

TRT-555

## Local Test Steps

* Pull this branch locally.
* Run the tests - they should all pass.
* Bonus 1: If you have a file you like to parse and a configuration file, then update the configuration file to the new schema and instantiate a `VarInfoFromNetCDF4` object to check functionality still behaves as expected. If you don't have a local configuration file, then you can grab the `tests/unit/data/test_config.json` and start with that.
* Bonus 2: If you want to test this specific functionality, then amend your local configuration file to have a couple of rules for the same attribute (different values and different levels of specificity in the `Variable_Pattern` applicability). When retrieving the attributes for a variable parsed by `VarInfoFromNetCDF4`, the more specific attribute override should be used.

Example content for a configuration file (update values for mission, short name, variable pattern, etc):

```
{
  ...
  "CF_Overrides": [
    {
      "Applicability": {
        "Mission": "FakeSat",
        "ShortNamePath": "FAKE99",
        "Variable_Pattern": "/.*"
      },
      "Attributes": [
        {
          "Name": "attribute_name",
          "Value": "value_being_ignored"
        }
      ]
    },
    {
      "Applicability": {
        "Mission": "FakeSat",
        "ShortNamePath": "FAKE99",
        "Variable_Pattern": "/group/variable"
      },
       "Attributes": [
        {
          "Name": "attribute_name",
          "Value": "value_taking_precedence"
        }
      ]
    }
  ]
}
```

## PR Acceptance Checklist
* [x] Jira ticket acceptance criteria met.
* [x] `CHANGELOG.md` updated to include high level summary of PR changes.
* [x] `VERSION` updated if publishing a release.
* [x] Tests added/updated and passing.
* [x] Documentation updated (if needed).