### PR TITLE
Trt 556 final schema clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,34 +13,34 @@ an input file.
 
 ### Changed:
 
-* Handling of nested `Applicability_Groups` has been removed from the `CFConfig`
-  class, as the configuration file no longer nests these items in overrides
-  or supplements.
-* CF Overrides retrieved for a matching file path are ordered such that the
-  most specific applicable override to the variable takes precedence. For
+* `CFConfig.get_cf_attributes` has been renamed `CFConfig.get_metadata_overrides`,
+  as there are now only overrides to be returned from this method. Calls to
+  `CFConfig.get_metadata_overrides` now _must_ specify a variable path. All
+  overrides from a configuration file for a given collection are now retrievable
+  from the newly public `CFConfig.metadata_overrides` class attribute.
+* Metadata overrides retrieved for a matching file path are ordered such that
+  the most specific applicable override to the variable takes precedence. For
   example, when requesting the value of the "units" metadata attribute for
   variable "/nested/variable", an applicability rule that exactly matches this
   variable path will take precedence over rules matching to either the group,
   or all variables in the file.
-* `CFConfig.get_cf_attributes` has been renamed `CFConfig.get_cf_overrides`, as
-  there are now only overrides to be returned from this method.
-  `CFConfig.get_cf_overrides` now _must_ specify a variable path. All overrides
-  from a configuration file for a given collection are now retrievable from
-  the newly public `CFConfig.cf_overrides` class attribute.
+* Handling of nested `Applicability_Groups` has been removed from the `CFConfig`
+  class, as the configuration file no longer nests these items in overrides.
 
 ### Removed:
 
 * `CFConfig._cf_supplements` has been deprecated in favour of specifying all
-  in-file metadata changes via a CF override instead.
+  in-file metadata changes via a `MetadataOverrides` item (formerly
+  `CFOverrides`) instead.
 
 ## v2.3.0
 ### 2024-08-26
 
-The VarInfoBase.get_missing_variable_attributes method has been added to allow
+The `VarInfoBase.get_missing_variable_attributes` method has been added to allow
 someone to get metadata attributes from the configuration file for variables
 that are absent from a file. An example usage is when a CF Convention grid
 mapping variable is missing from a source file.
-The VarInfoBase.get_references_for_attribute method has been added to retrieve
+The `VarInfoBase.get_references_for_attribute` method has been added to retrieve
 all unique variable references contained in a single metadata attribute for a
 list of variables. For example, retrieving all references listed under the
 coordinates metadata attribute.
@@ -48,8 +48,9 @@ coordinates metadata attribute.
 ## v2.2.2
 ### 2024-07-16
 
-The generate_collection_umm_var function in earthdata-varinfo updated to support an
-optional kwarg 'config_file=' for a configuration file, to be able to override known metadata errors.
+The `generate_collection_umm_var` function in earthdata-varinfo updated to
+support an optional kwarg `config_file` for a configuration file, to be able to
+override known metadata errors.
 
 
 ## v2.2.1

--- a/config/1.0.0/earthdata_varinfo_configuration_schema.json
+++ b/config/1.0.0/earthdata_varinfo_configuration_schema.json
@@ -43,11 +43,11 @@
         "$ref": "#/$defs/MissionVariablePatternType"
       }
     },
-    "CFOverrides": {
+    "MetadataOverrides": {
       "description": "# For cases where CF references do not exist, or are invalid. For example, variables that have no dimension references in the HDF-5 file contents",
       "type": "array",
       "items": {
-        "$ref": "#/$defs/CFOverridesItemType"
+        "$ref": "#/$defs/MetadataOverridesItemType"
       }
     }
   },
@@ -126,7 +126,7 @@
       "required": ["Applicability", "VariablePattern"],
       "additionalProperties": false
     },
-    "CFOverridesItemType": {
+    "MetadataOverridesItemType": {
       "description": "An item that details one or more metadata attributes to overwrite according to the supplied applicability rules.",
       "type": "object",
       "properties": {

--- a/config/1.0.0/earthdata_varinfo_configuration_schema.json
+++ b/config/1.0.0/earthdata_varinfo_configuration_schema.json
@@ -14,7 +14,7 @@
       "description": "A numeric identifier for the version of the specific configuration file (not the schema version itself).",
       "type": "integer"
     },
-    "Collection_ShortName_Path": {
+    "CollectionShortNamePath": {
       "description": "A list of HDF metadata attribute paths that provide the shortname value of the collection for the data file being processed. Processed in the listed order.",
       "type": "array",
       "items": {
@@ -29,167 +29,21 @@
         "type": "string"
       }
     },
-    "Excluded_Science_Variables": {
-      "description": "VarInfo classes currently assume that any variable that has a grid mapping attribute, or has a spatial or temporal dimension and is not itself a dimension or bounds variable, should be treated as a science variable. This may not be true in all cases, and so Excluded_Science_Variables provide a method to denote non-science variables that might otherwise be incorrectly identified.",
+    "ExcludedScienceVariables": {
+      "description": "VarInfo classes currently assume that any variable that has a grid mapping attribute, or has a spatial or temporal dimension and is not itself a dimension or bounds variable, should be treated as a science variable. This may not be true in all cases, and so ExcludedScienceVariables provide a method to denote non-science variables that might otherwise be incorrectly identified.",
       "type": "array",
       "items": {
         "$ref": "#/$defs/MissionVariablePatternType"
       }
     },
-    "Required_Fields": {
-      "description": "# VarInfo classes will calculate a set of required fields (variables, subdatasets) for a given science variable. This setting imposes additional contents for the required fields list.",
+    "RequiredVariables": {
+      "description": "# VarInfo classes will calculate a set of required variables for a given science variable. This setting imposes additional contents for the required variables list.",
       "type": "array",
       "items": {
         "$ref": "#/$defs/MissionVariablePatternType"
       }
     },
-    "ProductEpochs": {
-      "description": "Temporal subsetting typically encounters time tags in data files as e.g., delta_time, where the time value is relative to a start-time for the collection of datafiles, referred to as the time epoch.",
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/ProductEpochType"
-      }
-    },
-    "Grid_Mapping_Data": {
-      "description": "A list of CF-Convention compliant grid_mapping objects, each containing the required metadata attributes associated with the grid mapping.",
-      "type": "array",
-      "items": {
-        "description": "An object containing the necessary CF-Convention metadata attributes to describe a single grid_mapping.",
-        "type": "object",
-        "properties": {
-          "Grid_Mapping_Dataset_Name": {
-            "description": "A non-CF-Convention name for the grid mapping that can be used for reference by earthdata-varinfo, e.g., \"EASE2_Global\".",
-            "type": "string"
-          },
-          "grid_mapping_name": {
-            "description": "The name used to identify the grid mapping.",
-            "type": "string"
-          },
-          "azimuth_of_central_line": {
-            "description": "Specifies a horizontal angle measured in degrees clockwise from North. Used by certain projections (e.g., Oblique Mercator) to define the orientation of the map projection relative to a reference direction.",
-            "type": "number"
-          },
-          "crs_wkt": {
-            "description": "This optional attribute may be used to specify multiple coordinate system properties in well-known text (WKT) format. The syntax must conform to the WKT format as specified in OGC_WKT-CRS. Use of the crs_wkt attribute is described in section CF-Conventions 5.6.1.",
-            "type": "string"
-          },
-          "earth_radius": {
-            "description": "Used to specify the radius, in metres, of the spherical figure used to approximate the shape of the Earth. This attribute should be specified for those projected coordinate reference systems in which the X-Y cartesian coordinates have been derived using a spherical Earth approximation. If the cartesian coordinates were derived using an ellipsoid, this attribute should not be defined. Example: 6371007, which is the radius of the GRS 1980 Authalic Sphere.",
-            "type": "number"
-          },
-          "false_easting": {
-            "description": "Applied to all abscissa values in the rectangular coordinates for a map projection in order to eliminate negative numbers. Expressed in the unit of the coordinate variable identified by the standard name projection_x_coordinate. If false_easting is not provided it is assumed to be 0. The formula to convert from the coordinate value as written in the projection_x_coordinate (xf) to a value (x0) used in a transformation without false_easting, i.e. false_easting = 0, is: x0 = xf - false_easting.",
-            "type": "number"
-          },
-          "false_northing": {
-            "description": "Applied to all ordinate values in the rectangular coordinates for a map projection in order to eliminate negative numbers. Expressed in the unit of the coordinate variable identified by the standard name projection_y_coordinate. If false_northing is not provided it is assumed to be 0. The formula to convert from the coordinate value as written in the projection_y_coordinate (yf) to a value (y0) used in a transformation without false_northing, i.e. false_northing = 0, is: y0 = yf - false_northing",
-            "type": "number"
-          },
-          "fixed_angle_axis": {
-            "description": "Indicates the axis on which the view is fixed in a hypothetical gimbal view model of the Earth, as used in the geostationary grid mapping. It corresponds to the inner-gimbal axis of the gimbal view model, whose axis of rotation moves about the outer-gimbal axis. This value can adopt two values, x or y, corresponding with the Earth’s E-W or N-S axis, respectively. The counterpart to this attribute is sweep_angle_axis. If set to x, sweep_angle_axis is y, and vice versa. If one of the attributes fixed_angle_axis or sweep_angle_axis is provided, the other is not mandatory, as they can be used to infer each other.",
-            "$ref": "#/$defs/AngleAxisEnum"
-          },
-          "geographic_crs_name": {
-            "description": "The name of the geographic coordinate reference system. Corresponds to a OGC WKT GEOGCS node name.",
-            "type": "string"
-          },
-          "geoid_name": {
-            "description": "The name of the estimate or model of the geoid being used as a datum, e.g. GEOID12B. Corresponds to an OGC WKT VERT_DATUM name. The geoid is the surface of constant geopotential that the ocean would follow if it were at rest. This attribute and geopotential_datum_name cannot both be specified.",
-            "type": "string"
-          },
-          "geopotential_datum_name": {
-            "description": "The name of an estimated surface of constant geopotential being used as a datum, e.g. NAVD88. Such a surface is often called an equipotential surface in geodesy. Corresponds to an OGC WKT VERT_DATUM name. This attribute and geoid_name cannot both be specified.",
-            "type": "string"
-          },
-          "grid_north_pole_latitude": {
-            "description": "True latitude (degrees_north) of the north pole of the rotated grid.",
-            "type": "number"
-          },
-          "grid_north_pole_longitude": {
-            "description": "True longitude (degrees_east) of the north pole of the rotated grid.",
-            "type": "number"
-          },
-          "horizontal_datum_name": {
-            "description": "The name of the geodetic (horizontal) datum, which corresponds to the procedure used to measure positions on the surface of the Earth. Valid datum names and their associated parameters are given in https://github.com/cf-convention/cf-conventions/wiki/Mapping-from-CF-Grid-Mapping-Attributes-to-CRS-WKT-Elements (horiz_datum.csv, OGC_DATUM_NAME column) and are obtained by transforming the EPSG name using the following rules (used by OGR and Cadcorp): convert all non alphanumeric characters (including +) to underscores, then strip any leading, trailing or repeating underscores. This is to ensure that named datums can be correctly identified for precise datum transformations (see https://github.com/cf-convention/cf-conventions/wiki/OGC-WKT-Coordinate-System-Issues for more details). Corresponds to a OGC WKT DATUM node name.",
-            "type": "string"
-          },
-          "inverse_flattening": {
-            "description": "    Used to specify the inverse flattening (1/f) of the ellipsoidal figure associated with the geodetic datum and used to approximate the shape of the Earth. The flattening (f) of the ellipsoid is related to the semi-major and semi-minor axes by the formula f = (a-b)/a. In the case of a spherical Earth this attribute should be omitted or set to zero. Example: 298.257222101 for the GRS 1980 ellipsoid. (Note: By convention the dimensions of an ellipsoid are specified using either the semi-major and semi-minor axis lengths, or the semi-major axis length and the inverse flattening. If all three attributes are specified then the supplied values must be consistent with the aforementioned formula.)",
-            "type": "number"
-          },
-          "latitude_of_projection_origin": {
-            "description": "The latitude (degrees_north) chosen as the origin of rectangular coordinates for a map projection. Domain: -90.0 <= latitude_of_projection_origin <= 90.0.",
-            "type": "number"
-          },
-          "longitude_of_central_meridian": {
-            "description": "The line of longitude (degrees_east) at the center of a map projection generally used as the basis for constructing the projection. Domain: -180.0 <= longitude_of_central_meridian < 180.0.",
-            "type": "number"
-          },
-          "longitude_of_prime_meridian": {
-            "description": "Specifies the longitude, with respect to Greenwich, of the prime meridian associated with the geodetic datum. The prime meridian defines the origin from which longitude values are determined. Not to be confused with the projection origin longitude (cf. longitude_of_projection_origin, a.k.a. central meridian) which defines the longitude of the map projection origin. Domain: -180.0 <= longitude_of_prime_meridian < 180.0 decimal degrees. Default = 0.0.",
-            "type": "number"
-          },
-          "longitude_of_projection_origin": {
-            "description": "    The longitude (degrees_east) chosen as the origin of rectangular coordinates for a map projection. Domain: -180.0 <= longitude_of_projection_origin < 180.0.",
-            "type": "number"
-          },
-          "north_pole_grid_longitude": {
-            "description": "Longitude (degrees) of the true north pole in the rotated grid.",
-            "type": "number"
-          },
-          "perspective_point_height": {
-            "description": "Records the height, in metres, of the map projection perspective point above the ellipsoid (or sphere). Used by perspective-type map projections, for example the Vertical Perspective Projection, which may be used to simulate the view from a Meteosat satellite.",
-            "type": "number"
-          },
-          "prime_meridian_name": {
-            "description": "The name of the prime meridian associated with the geodetic datum. Valid names are given in https://github.com/cf-convention/cf-conventions/wiki/Mapping-from-CF-Grid-Mapping-Attributes-to-CRS-WKT-Elements (prime_meridian.csv). Corresponds to a OGC WKT PRIMEM node name.",
-            "$ref": "#/$defs/PrimeMeridianNameEnum"
-          },
-          "projected_crs_name": {
-            "description": "The name of the projected coordinate reference system. Corresponds to a OGC WKT PROJCS node name.",
-            "type": "string"
-          },
-          "reference_ellipsoid_name": {
-            "description": "The name of the reference ellipsoid. Valid names are given in https://github.com/cf-convention/cf-conventions/wiki/Mapping-from-CF-Grid-Mapping-Attributes-to-CRS-WKT-Elements (ellipsoid.csv). Corresponds to a OGC WKT SPHEROID node name.",
-            "type": "string"
-          },
-          "scale_factor_at_central_meridian": {
-            "description": "A multiplier for reducing a distance obtained from a map by computation or scaling to the actual distance along the central meridian. Domain: scale_factor_at_central_meridian > 0.0.",
-            "type": "number"
-          },
-          "scale_factor_at_projection_origin": {
-            "description": "A multiplier for reducing a distance obtained from a map by computation or scaling to the actual distance at the projection origin. Domain: scale_factor_at_projection_origin > 0.0.",
-            "type": "number"
-          },
-          "semi_major_axis": {
-            "description": "Specifies the length, in metres, of the semi-major axis of the ellipsoidal figure associated with the geodetic datum and used to approximate the shape of the Earth. Commonly denoted using the symbol a. In the case of a spherical Earth approximation this attribute defines the radius of the Earth. See also the inverse_flattening attribute.",
-            "type": "number"
-          },
-          "semi_minor_axis": {
-            "description": "Specifies the length, in metres, of the semi-minor axis of the ellipsoidal figure associated with the geodetic datum and used to approximate the shape of the Earth. Commonly denoted using the symbol b. In the case of a spherical Earth approximation this attribute should be omitted (the preferred option) or else set equal to the value of the semi_major_axis attribute. See also the inverse_flattening attribute.",
-            "type": "number"
-          },
-          "standard_parallel": {
-            "description": "Specifies the line, or lines, of latitude at which the developable map projection surface (plane, cone, or cylinder) touches the reference sphere or ellipsoid used to represent the Earth. Since there is zero scale distortion along a standard parallel it is also referred to as a latitude of true scale. In the situation where a conical developable surface intersects the reference ellipsoid there are two standard parallels, in which case this attribute can be used as a vector to record both latitude values, with the additional convention that the standard parallel nearest the pole (N or S) is provided first. Domain: -90.0 <= standard_parallel <= 90.0.",
-            "type": "number"
-          },
-          "straight_vertical_longitude_from_pole": {
-            "description": "The longitude (degrees_east) to be oriented straight up from the North or South Pole. Domain: -180.0 <= straight_vertical_longitude_from_pole < 180.0.",
-            "type": "number"
-          },
-          "sweep_angle_axis": {
-            "description": "Indicates the axis on which the view sweeps in a hypothetical gimbal view model of the Earth, as used in the geostationary grid mapping. It corresponds to the outer-gimbal axis of the gimbal view model, about whose axis of rotation the gimbal-gimbal axis moves. This value can adopt two values, x or y, corresponding with the Earth’s E-W or N-S axis, respectively. The counterpart to this attribute is fixed_angle_axis. If set to x, fixed_angle_axis is y, and vice versa. If one of the attributes fixed_angle_axis or sweep_angle_axis is provided, the other is not mandatory, as they can be used to infer each other.",
-            "$ref": "#/$defs/AngleAxisEnum"
-          },
-          "towgs84": {
-            "description": "This indicates a list of up to 7 Bursa Wolf transformation parameters., which can be used to approximate a transformation from the horizontal datum to the WGS84 datum. More precise datum transformations can be done with datum shift grids. Represented as a double-precision array, with 3, 6 or 7 values (if there are less than 7 values the remaining are considered to be zero). Corresponds to a OGC WKT TOWGS84 node.",
-            "type": "number"
-          }
-        },
-        "required": ["Grid_Mapping_Dataset_Name", "grid_mapping_name"]
-      }
-    },
-    "CF_Overrides": {
+    "CFOverrides": {
       "description": "# For cases where CF references do not exist, or are invalid. For example, variables that have no dimension references in the HDF-5 file contents",
       "type": "array",
       "items": {
@@ -197,7 +51,7 @@
       }
     }
   },
-  "required": ["Identification", "Version", "Collection_ShortName_Path", "Mission"],
+  "required": ["Identification", "Version", "CollectionShortNamePath", "Mission"],
   "$defs": {
     "ApplicabilityType": {
       "description": "An object that specifies a combination of satellite mission, collection short name and variable patterns to which a set of attributes should be applied. At least one of those properties must be specified.",
@@ -211,7 +65,7 @@
           "description": "The short name for the collection to which a granule belongs.",
           "type": "string"
         },
-        "Variable_Pattern": {
+        "VariablePattern": {
           "description": "A regular expression identifying all variables to which the schema item should be applied.",
           "type": "string"
         }
@@ -253,23 +107,6 @@
         "$ref": "#/$defs/AttributesItemType"
       }
     },
-    "ProductEpochType": {
-      "description": "An object containing a mission and its associated epoch in an ISO-8601 datetime format.",
-      "type": "object",
-      "properties": {
-        "Applicability": {
-          "description": "An applicability rule, containing the mission, or potentially also the collection short name.",
-          "$ref": "#/$defs/ApplicabilityType"
-        },
-        "Epoch": {
-          "description": "An ISO-8601 compatible datetime string.",
-          "type": "string",
-          "format": "date-time"
-        }
-      },
-      "required": ["Applicability", "Epoch"],
-      "additionalProperties": false
-    },
     "MissionVariablePatternType": {
       "description": "An object that defines a list of variables, as strings or regular expressions, that should be considered as either required variables or excluded as science variables for a given collection.",
       "type": "object",
@@ -278,7 +115,7 @@
           "description": "The mission and/or collection short name to which the list of required variables or excluded variables should be applied.",
           "$ref": "#/$defs/ApplicabilityType"
         },
-        "Variable_Pattern": {
+        "VariablePattern": {
           "description": "A list of variable strings or regular expression patterns that should match variables to be excluded or required for a given collection or mission.",
           "type": "array",
           "items": {
@@ -286,7 +123,7 @@
           }
         }
       },
-      "required": ["Applicability", "Variable_Pattern"],
+      "required": ["Applicability", "VariablePattern"],
       "additionalProperties": false
     },
     "CFOverridesItemType": {
@@ -298,11 +135,11 @@
           "type": "string"
         },
         "Applicability": {
-          "description": "An applicability rule that indicates which groups and variables within a file a metadata override should apply to. If only a short name and/or mission is provided, the override will apply to all groups and variables. If a Variable_Pattern is also provided, the override is applied only to those groups or variables whose paths match the regular expression of the Variable_Pattern.",
+          "description": "An applicability rule that indicates which groups and variables within a file a metadata override should apply to. If only a short name and/or mission is provided, the override will apply to all groups and variables. If a VariablePattern is also provided, the override is applied only to those groups or variables whose paths match the regular expression of the VariablePattern.",
           "$ref": "#/$defs/ApplicabilityType"
         },
         "Attributes" : {
-          "description": "Metadata attributes to override for variables or groups that match the mission, short name and/or Variable_Pattern criteria specified in the Applicability of this object.",
+          "description": "Metadata attributes to override for variables or groups that match the mission, short name and/or VariablePattern criteria specified in the Applicability of this object.",
           "type": "array",
           "items": {
             "description": "A list of metadata attributes with their names and values.",
@@ -312,16 +149,6 @@
       },
       "additionalProperties": false,
       "required": ["Applicability", "Attributes"]
-    },
-    "AngleAxisEnum": {
-      "description": "Used for grid_mapping properties fixed_angle_axis and sweep_angle_axis.",
-      "type": "string",
-      "enum": ["x", "y"]
-    },
-    "PrimeMeridianNameEnum": {
-      "description": "Valid names for the prime_meridian_name grid_mapping attribute.",
-      "type": "string",
-      "enum": ["Greenwich", "Lisbon", "Paris", "Bogota", "Madrid", "Rome", "Bern", "Jakarta", "Ferro", "Brussels", "Stockholm", "Athens", "Oslo", "Paris RGS"]
     }
   }
 }

--- a/config/1.0.0/sample_config_1.0.0.json
+++ b/config/1.0.0/sample_config_1.0.0.json
@@ -1,7 +1,7 @@
 {
   "Identification": "varinfo_sample_config",
   "Version": 15,
-  "Collection_ShortName_Path": [
+  "CollectionShortNamePath": [
     "/HDF5_GLOBAL/short_name",
     "/NC_GLOBAL/short_name",
     "/Metadata/DatasetIdentification/shortName",
@@ -18,61 +18,29 @@
     "SPL[1234].+": "SMAP",
     "VIIRS_NPP-.+-L2P": "VIIRS_PO"
   },
-  "Excluded_Science_Variables": [
+  "ExcludedScienceVariables": [
     {
       "Applicability": {
         "Mission": "ICESat2"
       },
-      "Variable_Pattern": [
+      "VariablePattern": [
         "/quality_assessment/.*",
         "/orbit_info/.*",
         "/atlas_impulse_response/.*"
       ]
     }
   ],
-  "Required_Fields": [
+  "RequiredVariables": [
     {
       "Applicability": {
         "Mission": "GEDI"
       },
-      "Variable_Pattern": [
+      "VariablePattern": [
         ".*shot_number"
       ]
     }
   ],
-  "ProductEpochs": [
-    {
-      "Applicability": {
-        "Mission": "ICESat2"
-      },
-      "Epoch": "2005-01-01T00:00:00.000000"
-    },
-    {
-      "Applicability": {
-        "Mission": "GEDI"
-      },
-      "Epoch": "2018-01-01T00:00:00.000000"
-    }
-  ],
-  "Grid_Mapping_Data": [
-    {
-      "Grid_Mapping_Dataset_Name": "EASE2_Global",
-      "grid_mapping_name": "lambert_cylindrical_equal_area",
-      "standard_parallel": 30.0,
-      "longitude_of_central_meridian": 0.0,
-      "false_easting": 0.0,
-      "false_northing": 0.0
-    },
-    {
-      "Grid_Mapping_Dataset_Name": "EASE2_Polar",
-      "grid_mapping_name": "lambert_azimuthal_equal_area",
-      "longitude_of_projection_origin": 0.0,
-      "latitude_of_projection_origin": 90.0,
-      "false_easting": 0.0,
-      "false_northing": 0.0
-    }
-  ],
-  "CF_Overrides": [
+  "CFOverrides": [
     {
       "Applicability": {
         "Mission": "SMAP",
@@ -80,8 +48,37 @@
       },
       "Attributes": [
         {
-          "Name": "Grid_Mapping",
-          "Value": "EASE2_Global"
+          "Name": "grid_mapping",
+          "Value": "/EASE2_global_projection"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL4.*",
+        "VariablePattern": "/EASE2_global_projection"
+      },
+      "Attributes": [
+        {
+          "Name": "false_easting",
+          "Value": 0.0
+        },
+        {
+          "Name": "false_northing",
+          "Value": 0.0
+        },
+        {
+          "Name": "grid_mapping_name",
+          "Value": "lambert_cylindrical_equal_area"
+        },
+        {
+          "Name": "longitude_of_central_meridian",
+          "Value": 0.0
+        },
+        {
+          "Name": "standard_parallel",
+          "Value": 30.0
         }
       ]
     },
@@ -89,12 +86,12 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3FT(P|P_E)",
-        "Variable_Pattern": "(?i).*global.*"
+        "VariablePattern": "(?i).*global.*"
       },
       "Attributes": [
         {
-          "Name": "Grid_Mapping",
-          "Value": "EASE2_Global"
+          "Name": "grid_mapping",
+          "Value": "/EASE2_global_projection"
         }
       ]
     },
@@ -102,12 +99,70 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3FT(P|P_E)",
-        "Variable_Pattern": "(?i).*polar.*"
+        "VariablePattern": "/EASE2_global_projection"
       },
       "Attributes": [
         {
-          "Name": "Grid_Mapping",
-          "Value": "EASE2_Polar"
+          "Name": "false_easting",
+          "Value": 0.0
+        },
+        {
+          "Name": "false_northing",
+          "Value": 0.0
+        },
+        {
+          "Name": "grid_mapping_name",
+          "Value": "lambert_cylindrical_equal_area"
+        },
+        {
+          "Name": "longitude_of_central_meridian",
+          "Value": 0.0
+        },
+        {
+          "Name": "standard_parallel",
+          "Value": 30.0
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FT(P|P_E)",
+        "VariablePattern": "(?i).*polar.*"
+      },
+      "Attributes": [
+        {
+          "Name": "grid_mapping",
+          "Value": "/EASE2_polar_projection"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FT(P|P_E)",
+        "VariablePattern": "/EASE2_polar_projection"
+      },
+      "Attributes": [
+        {
+          "Name": "false_easting",
+          "Value": 0.0
+        },
+        {
+          "Name": "false_northing",
+          "Value": 0.0
+        },
+        {
+          "Name": "grid_mapping_name",
+          "Value": "lambert_azimuthal_equal_area"
+        },
+        {
+          "Name": "latitude_of_projection_origin",
+          "Value": 90.0
+        },
+        {
+          "Name": "longitude_of_projection_origin",
+          "Value": 0.0
         }
       ]
     },
@@ -118,8 +173,37 @@
       },
       "Attributes": [
         {
-          "Name": "Grid_Mapping",
-          "Value": "EASE2_Polar"
+          "Name": "grid_mapping",
+          "Value": "/EASE2_polar_projection"
+        }
+      ]
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FTA",
+        "VariablePattern": "/EASE2_polar_projection"
+      },
+      "Attributes": [
+        {
+          "Name": "false_easting",
+          "Value": 0.0
+        },
+        {
+          "Name": "false_northing",
+          "Value": 0.0
+        },
+        {
+          "Name": "grid_mapping_name",
+          "Value": "lambert_azimuthal_equal_area"
+        },
+        {
+          "Name": "latitude_of_projection_origin",
+          "Value": 90.0
+        },
+        {
+          "Name": "longitude_of_projection_origin",
+          "Value": 0.0
         }
       ]
     },
@@ -127,7 +211,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3FT(A|P|P_E)",
-        "Variable_Pattern": "/Freeze_Thaw_Retrieval_Data_Polar/(latitude|longitude).*"
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data_Polar/(latitude|longitude).*"
       },
       "Attributes": [
         {
@@ -140,7 +224,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3SMP_E",
-        "Variable_Pattern": "/$"
+        "VariablePattern": "/$"
       },
       "Attributes": [
         {
@@ -153,7 +237,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3SMP_E",
-        "Variable_Pattern": "/Soil_Moisture_Retrieval_Data_AM/.*"
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_AM/.*"
       },
       "Attributes": [
         {
@@ -166,7 +250,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3SMP_E",
-        "Variable_Pattern": "/Soil_Moisture_Retrieval_Data_PM/.*"
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_PM/.*"
       },
       "Attributes": [
         {
@@ -179,7 +263,7 @@
       "Applicability": {
         "Mission": "ICESat2",
         "ShortNamePath": "ATL20",
-        "Variable_Pattern": "/daily/day\\d{2}/.+"
+        "VariablePattern": "/daily/day\\d{2}/.+"
       },
       "Attributes": [
         {
@@ -196,7 +280,7 @@
       "Applicability": {
         "Mission": "ICESat2",
         "ShortNamePath": "ATL0[3-9]|ATL1[023]",
-        "Variable_Pattern": "/$"
+        "VariablePattern": "/$"
       },
       "Attributes": [
         {
@@ -209,7 +293,7 @@
       "Applicability": {
         "Mission": "ICESat2",
         "ShortNamePath": "ATL0[3-9]|ATL1[023]",
-        "Variable_Pattern": "/gt[123][lr]/geolocation/.*"
+        "VariablePattern": "/gt[123][lr]/geolocation/.*"
       },
       "Attributes": [
         {
@@ -222,7 +306,7 @@
       "Applicability": {
         "Mission": "ICESat2",
         "ShortNamePath": "ATL03",
-        "Variable_Pattern": "/gt[123][lr]/geophys_corr/.*"
+        "VariablePattern": "/gt[123][lr]/geophys_corr/.*"
       },
       "Attributes": [
         {
@@ -239,7 +323,7 @@
       "Applicability": {
         "Mission": "ICESat2",
         "ShortNamePath": "ATL03",
-        "Variable_Pattern": "/gt[123][lr]/heights/.*"
+        "VariablePattern": "/gt[123][lr]/heights/.*"
       },
       "Attributes": [
         {
@@ -256,7 +340,7 @@
       "Applicability": {
         "Mission": "ICESat2",
         "ShortNamePath": "ATL03",
-        "Variable_Pattern": "/gt[123][lr]/geolocation/ph_index_beg"
+        "VariablePattern": "/gt[123][lr]/geolocation/ph_index_beg"
       },
       "Attributes": [
         {
@@ -269,7 +353,7 @@
       "Applicability": {
         "Mission": "ICESat2",
         "ShortNamePath": "ATL03",
-        "Variable_Pattern": "/gt[123][lr]/geolocation/ph_index_beg"
+        "VariablePattern": "/gt[123][lr]/geolocation/ph_index_beg"
       },
       "Attributes": [
         {
@@ -282,7 +366,7 @@
       "Applicability": {
         "Mission": "ICESat2",
         "ShortNamePath": "ATL08",
-        "Variable_Pattern": "/gt[123][lr]/signal_photons/.*"
+        "VariablePattern": "/gt[123][lr]/signal_photons/.*"
       },
       "Attributes": [
         {
@@ -299,7 +383,7 @@
       "Applicability": {
         "Mission": "ICESat2",
         "ShortNamePath": "ATL08",
-        "Variable_Pattern": "/gt[123][lr]/land_segments/ph_ndx_beg"
+        "VariablePattern": "/gt[123][lr]/land_segments/ph_ndx_beg"
       },
       "Attributes": [
         {
@@ -312,7 +396,7 @@
       "Applicability": {
         "Mission": "ICESat2",
         "ShortNamePath": "ATL08",
-        "Variable_Pattern": "/gt[123][lr]/land_segments/n_seg_ph"
+        "VariablePattern": "/gt[123][lr]/land_segments/n_seg_ph"
       },
       "Attributes": [
         {
@@ -325,7 +409,7 @@
       "Applicability": {
         "Mission": "ICESat2",
         "ShortNamePath": "ATL1[67]",
-        "Variable_Pattern": "/$"
+        "VariablePattern": "/$"
       },
       "Attributes": [
         {
@@ -338,7 +422,7 @@
       "Applicability": {
         "Mission": "ICESat2",
         "ShortNamePath": "ATL20",
-        "Variable_Pattern": "/$"
+        "VariablePattern": "/$"
       },
       "Attributes": [
         {
@@ -351,7 +435,7 @@
       "Applicability": {
         "Mission": "ICESat2",
         "ShortNamePath": "ATL20",
-        "Variable_Pattern": ".*"
+        "VariablePattern": ".*"
       },
       "Attributes": [
         {
@@ -364,7 +448,7 @@
       "Applicability": {
         "Mission": "GEDI",
         "ShortNamePath": "GEDI_L[1234][AB]|GEDI0[1234]_[AB]",
-        "Variable_Pattern": "/$"
+        "VariablePattern": "/$"
       },
       "Attributes": [
         {
@@ -377,7 +461,7 @@
       "Applicability": {
         "Mission": "GEDI",
         "ShortNamePath": "GEDI_L2B|GEDI02_B",
-        "Variable_Pattern": "/BEAM[\\d]+/pgap_theta_z"
+        "VariablePattern": "/BEAM[\\d]+/pgap_theta_z"
       },
       "Attributes": [
         {
@@ -394,7 +478,7 @@
       "Applicability": {
         "Mission": "GEDI",
         "ShortNamePath": "GEDI_L2B|GEDI02_B",
-        "Variable_Pattern": "/BEAM[\\d]+/rx_sample_start_index"
+        "VariablePattern": "/BEAM[\\d]+/rx_sample_start_index"
       },
       "Attributes": [
         {
@@ -407,7 +491,7 @@
       "Applicability": {
         "Mission": "GEDI",
         "ShortNamePath": "GEDI_L2B|GEDI02_B",
-        "Variable_Pattern": "/BEAM[\\d]+/rx_sample_count"
+        "VariablePattern": "/BEAM[\\d]+/rx_sample_count"
       },
       "Attributes": [
         {

--- a/config/1.0.0/sample_config_1.0.0.json
+++ b/config/1.0.0/sample_config_1.0.0.json
@@ -40,7 +40,7 @@
       ]
     }
   ],
-  "CFOverrides": [
+  "MetadataOverrides": [
     {
       "Applicability": {
         "Mission": "SMAP",

--- a/config/CHANGELOG.md
+++ b/config/CHANGELOG.md
@@ -13,31 +13,36 @@ to simplify the schema for broader use.
 
 ### Changed:
 
+* `CF_Overrides` has been renamed to `MetadataOverrides`.
+* `CFOverridesOrSupplementsItemType` has been renamed to
+  `MetadataOverridesItemType`.
+* `Required_Fields` has been renamed to `RequiredVariables` to match the
+  terminology used for other schema properties.
 * The casing of all attributes in the configuration file schema has been
   updated to be `PascalCase` throughout. Affected schema attributes include:
-  * `CFOverrides`
-  * `CollectionShortNamePath`
-  * `ExcludedScienceVariables`
-  * `RequiredVariables` (formerly `Required_Fields`).
+  * `CollectionShortNamePath`.
+  * `ExcludedScienceVariables`.
 
 ### Removed:
-* The `Global_Attributes` property has been removed from the `CF_Overrides` and
-  `CF_Supplements` items, in favour of specifying group metadata attribute
-  overrides in the same way as variables. That is: specifying the group in the
-  `Applicability` part of the item, and including the updated attributes under
-  the `Attributes` property of the item. This allows metadata overrides to all
-  groups, not just the global attributes in an input file.
-* The `Applicability_Group` property within `CF_Overrides` and `CF_Supplements`
-  has been removed. Now attributes should only be specified within the
-  `Attributes` property at the root level of an override or supplement. The
-  `Applicability` of a `CF_Override` or `CF_Supplement` must now include either
-  a `Mission` or a `ShortNamePath`.
-* The `CF_Supplements` section of the `CFOverridesOrSupplementItemType` has
-  been removed, and the item type renamed to `CFOverridesItemType`. All changes
-  to in-file metadata attributes should now be specified in `CF_Overrides`.
+
+* The `CF_Supplements` property of the schema has been removed. All metadata
+  changes must now be specified in a `MetadataOverrides` item (formerly
+  `CF_Overrides`).
+* The `Global_Attributes` property has been removed from `MetadataOverrides`.
+  Global attribute overrides should now be specified in the same way as
+  metadata attributes on any other variable or group. That is: specifying the
+  path to the group in the `Applicability` part of the item, and including the
+  updated attributes under the `Attributes` property of the item. This allows
+  metadata overrides to all groups, not just the global attributes in an input
+  file.
+* The `Applicability_Group` property within `MetadataOverrides` (formerly
+  `CF_Overrides`) has been removed. Now attributes should only be specified
+  within the `Attributes` property at the root level of an override or
+  supplement. The `Applicability` of a `MetadataOverrides` item must now
+  include either a `Mission` or a `ShortNamePath`.
 * The unused `ProductEpochs` section of the schema has been removed.
 * The `Grid_Mapping_Data` section of the schema has been removed, in favour of
-  specifying grid mapping attributes via `CF_Overrides`.
+  specifying grid mapping attributes via `MetadataOverrides`.
 
 ## 0.0.1
 ### 2023-01-09

--- a/config/CHANGELOG.md
+++ b/config/CHANGELOG.md
@@ -11,6 +11,15 @@ the earthdata-varinfo configuration file.
 This version of the configuration file schema makes several significant changes
 to simplify the schema for broader use.
 
+### Changed:
+
+* The casing of all attributes in the configuration file schema has been
+  updated to be `PascalCase` throughout. Affected schema attributes include:
+  * `CFOverrides`
+  * `CollectionShortNamePath`
+  * `ExcludedScienceVariables`
+  * `RequiredVariables` (formerly `Required_Fields`).
+
 ### Removed:
 * The `Global_Attributes` property has been removed from the `CF_Overrides` and
   `CF_Supplements` items, in favour of specifying group metadata attribute
@@ -26,6 +35,9 @@ to simplify the schema for broader use.
 * The `CF_Supplements` section of the `CFOverridesOrSupplementItemType` has
   been removed, and the item type renamed to `CFOverridesItemType`. All changes
   to in-file metadata attributes should now be specified in `CF_Overrides`.
+* The unused `ProductEpochs` section of the schema has been removed.
+* The `Grid_Mapping_Data` section of the schema has been removed, in favour of
+  specifying grid mapping attributes via `CF_Overrides`.
 
 ## 0.0.1
 ### 2023-01-09

--- a/tests/unit/data/test_config.json
+++ b/tests/unit/data/test_config.json
@@ -40,7 +40,7 @@
       ]
     }
   ],
-  "CFOverrides": [
+  "MetadataOverrides": [
     {
       "Applicability": {
         "Mission": "FakeSat",

--- a/tests/unit/data/test_config.json
+++ b/tests/unit/data/test_config.json
@@ -1,68 +1,46 @@
 {
   "Identification": "var_subsetter_config",
-  "Version": 12,
-  "Collection_ShortName_Path": [
+  "Version": 13,
+  "CollectionShortNamePath": [
     "/HDF5_GLOBAL/short_name",
     "/NC_GLOBAL/short_name",
     "/Metadata/DatasetIdentification/shortName",
     "/METADATA/DatasetIdentification/shortName",
     "/Metadata/SeriesIdentification/shortName",
     "/METADATA/SeriesIdentification/shortName",
+    "short_name",
     "/id"
   ],
   "Mission": {
     "FAKE\\d{2}": "FakeSat",
-    "ATL03": "ICESat2"
+    "ATL03": "ICESat2",
+    "GEDI_L[1234][AB]|GEDI0[1234]_[AB]": "GEDI",
+    "SPL[1234].+": "SMAP",
+    "VIIRS_NPP-.+-L2P": "VIIRS_PO"
   },
-  "Excluded_Science_Variables": [
+  "ExcludedScienceVariables": [
     {
       "Applicability": {
         "Mission": "FakeSat"
       },
-      "Variable_Pattern": [
+      "VariablePattern": [
         "/exclude_one/.*",
         "/exclude_two/.*",
         "/exclude_three/.*"
       ]
     }
   ],
-  "Required_Fields": [
+  "RequiredVariables": [
     {
       "Applicability": {
         "Mission": "FakeSat"
       },
-      "Variable_Pattern": [
+      "VariablePattern": [
         "/required_group/.*"
       ]
     }
   ],
-  "ProductEpochs": [
-    {
-      "Applicability": {
-        "Mission": "FakeSat"
-      },
-      "Epoch": "2005-01-01T00:00:00.000000"
-    }
-  ],
-  "Grid_Mapping_Data": [
-    {
-      "Grid_Mapping_Dataset_Name": "EASE2_Global",
-      "grid_mapping_name": "lambert_cylindrical_equal_area",
-      "standard_parallel": 30.0,
-      "longitude_of_central_meridian": 0.0,
-      "false_easting": 0.0,
-      "false_northing": 0.0
-    },
-    {
-      "Grid_Mapping_Dataset_Name": "EASE2_Polar",
-      "grid_mapping_name": "lambert_azimuthal_equal_area",
-      "longitude_of_projection_origin": 0.0,
-      "latitude_of_projection_origin": 90.0,
-      "false_easting": 0.0,
-      "false_northing": 0.0
-    }
-  ],
-  "CF_Overrides": [
+  "CFOverrides": [
     {
       "Applicability": {
         "Mission": "FakeSat",
@@ -79,7 +57,7 @@
       "Applicability": {
         "Mission": "FakeSat",
         "ShortNamePath": "FAKE99",
-        "Variable_Pattern": "/group/.*"
+        "VariablePattern": "/group/.*"
       },
       "Attributes": [
         {
@@ -92,7 +70,7 @@
       "Applicability": {
         "Mission": "FakeSat",
         "ShortNamePath": "FAKE99",
-        "Variable_Pattern": "/$"
+        "VariablePattern": "/$"
       },
       "Attributes": [
         {
@@ -105,7 +83,7 @@
       "Applicability": {
         "Mission": "FakeSat",
         "ShortNamePath": "FAKE99",
-        "Variable_Pattern": "/group/variable"
+        "VariablePattern": "/group/variable"
       },
       "Attributes": [
         {
@@ -118,7 +96,7 @@
       "Applicability": {
         "Mission": "FakeSat",
         "ShortNamePath": "FAKE99",
-        "Variable_Pattern": "/coordinates_group/.*"
+        "VariablePattern": "/coordinates_group/.*"
       },
       "Attributes": [
         {
@@ -131,7 +109,7 @@
       "Applicability": {
         "Mission": "FakeSat",
         "ShortNamePath": "FAKE99",
-        "Variable_Pattern": "/absent_variable"
+        "VariablePattern": "/absent_variable"
       },
       "Attributes": [
         {
@@ -144,7 +122,7 @@
       "Applicability": {
         "Mission": "FakeSat",
         "ShortNamePath": "FAKE98",
-        "Variable_Pattern": "/group2/.*"
+        "VariablePattern": "/group2/.*"
       },
       "Attributes": [
         {
@@ -157,7 +135,7 @@
       "Applicability": {
         "Mission": "FakeSat2",
         "ShortNamePath": "FAKE99",
-        "Variable_Pattern": "/group3/.*"
+        "VariablePattern": "/group3/.*"
       },
       "Attributes": [
         {
@@ -170,7 +148,7 @@
       "Applicability": {
         "Mission": "FakeSat",
         "ShortNamePath": "FAKE97",
-        "Variable_Pattern": "/.*"
+        "VariablePattern": "/.*"
       },
       "Attributes": [
         {
@@ -183,7 +161,7 @@
       "Applicability": {
         "Mission": "FakeSat",
         "ShortNamePath": "FAKE97",
-        "Variable_Pattern": "/group/.*"
+        "VariablePattern": "/group/.*"
       },
       "Attributes": [
         {
@@ -200,7 +178,7 @@
       "Applicability": {
         "Mission": "FakeSat",
         "ShortNamePath": "FAKE97",
-        "Variable_Pattern": "/group/variable"
+        "VariablePattern": "/group/variable"
       },
       "Attributes": [
         {
@@ -213,7 +191,7 @@
       "Applicability": {
         "Mission": "FakeSat",
         "ShortNamePath": "FAKE97",
-        "Variable_Pattern": "/other_group/variable"
+        "VariablePattern": "/other_group/variable"
       },
       "Attributes": [
         {
@@ -226,7 +204,7 @@
       "Applicability": {
         "Mission": "FakeSat",
         "ShortNamePath": "FAKE97",
-        "Variable_Pattern": "/(other_group|long|regex|things).*"
+        "VariablePattern": "/(other_group|long|regex|things).*"
       },
       "Attributes": [
         {
@@ -239,7 +217,7 @@
       "Applicability": {
         "Mission": "FakeSat",
         "ShortNamePath": "FAKE97",
-        "Variable_Pattern": "/string_length/variable"
+        "VariablePattern": "/string_length/variable"
       },
       "Attributes": [
         {
@@ -252,7 +230,7 @@
       "Applicability": {
         "Mission": "FakeSat",
         "ShortNamePath": "FAKE97",
-        "Variable_Pattern": "/string_length/var.*"
+        "VariablePattern": "/string_length/var.*"
       },
       "Attributes": [
         {

--- a/tests/unit/test_cf_config.py
+++ b/tests/unit/test_cf_config.py
@@ -142,7 +142,7 @@ class TestCFConfig(TestCase):
         matching metadata attribute takes precedence.
 
         The primary measure of specificity is the depth of the variable
-        hierarchy specified in the Variable_Pattern, with secondary sorting
+        hierarchy specified in the VariablePattern, with secondary sorting
         based upon the length of strings at the same hierarchy.
 
         """

--- a/tests/unit/test_cf_config.py
+++ b/tests/unit/test_cf_config.py
@@ -27,7 +27,7 @@ class TestCFConfig(TestCase):
             '/exclude_three/.*',
         }
         cls.required_variables = {'/required_group/.*'}
-        cls.expected_cf_overrides = {
+        cls.expected_metadata_overrides = {
             '.*': {'collection_override': 'collection value'},
             '/$': {'global_override': 'GLOBAL'},
             '/absent_variable': {'extra_override': 'overriding value'},
@@ -54,7 +54,10 @@ class TestCFConfig(TestCase):
         )
 
         self.assertSetEqual(self.required_variables, config.required_variables)
-        self.assertDictEqual(self.expected_cf_overrides, config.cf_overrides)
+        self.assertDictEqual(
+            self.expected_metadata_overrides,
+            config.metadata_overrides,
+        )
 
     def test_instantiation_no_file(self):
         """Ensure an instance of the `CFConfig` class can be produced when no
@@ -67,7 +70,7 @@ class TestCFConfig(TestCase):
         self.assertEqual(self.short_name, config.short_name)
         self.assertSetEqual(set(), config.excluded_science_variables)
         self.assertSetEqual(set(), config.required_variables)
-        self.assertDictEqual({}, config.cf_overrides)
+        self.assertDictEqual({}, config.metadata_overrides)
 
     def test_instantiation_missing_configuration_file(self):
         """Ensure a MissingConfigurationFileError is raised when a path to a
@@ -89,13 +92,14 @@ class TestCFConfig(TestCase):
                 config_file='tests/unit/data/ATL03_example.dmr',
             )
 
-    def test_get_cf_overrides_variable(self):
-        """Ensure the CFConfig.get_cf_overrides method returns all overriding
-        attributes where the variable pattern matches the supplied variable or
-        group name. If multiple patterns match the variable name, then the
-        pattern that is the most specific, as determined by a combination of
-        hierarchical depth in the regular expression and, secondarily, the
-        length of the variable pattern string, will be returned.
+    def test_get_metadata_overrides_variable(self):
+        """Ensure the CFConfig.get_metadata_overrides method returns all
+        overriding attributes where the variable pattern matches the supplied
+        variable or group name. If multiple patterns match the variable name,
+        then the pattern that is the most specific, as determined by a
+        combination of hierarchical depth in the regular expression and,
+        secondarily, the length of the variable pattern string, will be
+        returned.
 
         """
         expected_collection_overrides = {'collection_override': 'collection value'}
@@ -132,11 +136,11 @@ class TestCFConfig(TestCase):
         for description, variable, expected_overrides in test_args:
             with self.subTest(description):
                 self.assertDictEqual(
-                    config.get_cf_overrides(variable),
+                    config.get_metadata_overrides(variable),
                     expected_overrides,
                 )
 
-    def test_get_cf_overrides_variable_conflicts(self):
+    def test_get_metadata_overrides_variable_conflicts(self):
         """Ensure that if a variable matches multiple override rules that
         specify conflicting values for a metadata attribute, the most specific
         matching metadata attribute takes precedence.
@@ -150,7 +154,7 @@ class TestCFConfig(TestCase):
 
         with self.subTest('Deeper matches takes precedence over shallower'):
             self.assertDictEqual(
-                config.get_cf_overrides('/group/variable'),
+                config.get_metadata_overrides('/group/variable'),
                 {
                     'conflicting_attribute_global_and_group': 'applies to /group/.*',
                     'conflicting_attribute_group_and_variable': 'applies to /group/variable',
@@ -159,7 +163,7 @@ class TestCFConfig(TestCase):
 
         with self.subTest('Depth takes precedence over string length'):
             self.assertDictEqual(
-                config.get_cf_overrides('/other_group/variable'),
+                config.get_metadata_overrides('/other_group/variable'),
                 {
                     'conflicting_attribute_global_and_group': 'applies to all',
                     'test_depth_priority_over_string_length': 'applies to /other_group/variable',
@@ -168,7 +172,7 @@ class TestCFConfig(TestCase):
 
         with self.subTest('String length decides between matches of equal depth'):
             self.assertDictEqual(
-                config.get_cf_overrides('/string_length/variable'),
+                config.get_metadata_overrides('/string_length/variable'),
                 {
                     'conflicting_attribute_global_and_group': 'applies to all',
                     'test_string_length_same_depth': 'applies to /string_length/variable',

--- a/tests/unit/test_var_info.py
+++ b/tests/unit/test_var_info.py
@@ -20,9 +20,8 @@ class TestVarInfoFromDmr(TestCase):
         tests.
 
         """
-        cls.config_file = 'tests/unit/data/test_config.json'
+        cls.test_config_file = 'tests/unit/data/test_config.json'
         cls.namespace = 'namespace_string'
-        cls.sample_config = 'config/0.0.1/sample_config_0.0.1.json'
         cls.mock_geographic_dmr = 'tests/unit/data/mock_geographic.dmr'
         cls.mock_dmr_two = 'tests/unit/data/mock_dataset_two.dmr'
         cls.mock_geo_and_projected_dmr = 'tests/unit/data/mock_geo_and_projected.dmr'
@@ -131,7 +130,7 @@ class TestVarInfoFromDmr(TestCase):
                 )
                 dmr_path = write_dmr(self.output_dir, mock_dmr)
 
-                dataset = VarInfoFromDmr(dmr_path, config_file=self.sample_config)
+                dataset = VarInfoFromDmr(dmr_path, config_file=self.test_config_file)
 
                 self.assertEqual(dataset.short_name, short_name)
 
@@ -139,7 +138,7 @@ class TestVarInfoFromDmr(TestCase):
             mock_dmr = f'<Dataset xmlns="{self.namespace}"></Dataset>'
             dmr_path = write_dmr(self.output_dir, mock_dmr)
 
-            dataset = VarInfoFromDmr(dmr_path, config_file=self.sample_config)
+            dataset = VarInfoFromDmr(dmr_path, config_file=self.test_config_file)
 
             self.assertIsNone(dataset.short_name)
 
@@ -148,7 +147,7 @@ class TestVarInfoFromDmr(TestCase):
             dmr_path = write_dmr(self.output_dir, mock_dmr)
 
             dataset = VarInfoFromDmr(
-                dmr_path, short_name='ATL03', config_file=self.sample_config
+                dmr_path, short_name='ATL03', config_file=self.test_config_file
             )
 
             self.assertEqual(dataset.short_name, 'ATL03')
@@ -164,7 +163,7 @@ class TestVarInfoFromDmr(TestCase):
             dmr_path = write_dmr(self.output_dir, mock_dmr)
 
             dataset = VarInfoFromDmr(
-                dmr_path, short_name='ATL08', config_file=self.sample_config
+                dmr_path, short_name='ATL08', config_file=self.test_config_file
             )
             self.assertEqual(dataset.short_name, 'ATL08')
 
@@ -194,7 +193,7 @@ class TestVarInfoFromDmr(TestCase):
                 )
                 dmr_path = write_dmr(self.output_dir, mock_dmr)
 
-                dataset = VarInfoFromDmr(dmr_path, config_file=self.sample_config)
+                dataset = VarInfoFromDmr(dmr_path, config_file=self.test_config_file)
 
                 self.assertEqual(dataset.mission, expected_mission)
 
@@ -253,7 +252,9 @@ class TestVarInfoFromDmr(TestCase):
         and short name that do not have any CF overrides.
 
         """
-        dataset = VarInfoFromDmr(self.mock_geographic_dmr, config_file=self.config_file)
+        dataset = VarInfoFromDmr(
+            self.mock_geographic_dmr, config_file=self.test_config_file
+        )
 
         self.assertEqual(dataset.short_name, 'ATL03')
         self.assertEqual(dataset.mission, 'ICESat2')
@@ -300,7 +301,7 @@ class TestVarInfoFromDmr(TestCase):
         overrides in the CFConfig class.
 
         """
-        dataset = VarInfoFromDmr(self.mock_dmr_two, config_file=self.config_file)
+        dataset = VarInfoFromDmr(self.mock_dmr_two, config_file=self.test_config_file)
 
         expected_global_attributes = {
             'collection_override': 'collection value',
@@ -370,7 +371,7 @@ class TestVarInfoFromDmr(TestCase):
             '</Dataset>'
         )
         dmr_path = write_dmr(self.output_dir, mock_dmr)
-        dataset = VarInfoFromDmr(dmr_path, config_file=self.config_file)
+        dataset = VarInfoFromDmr(dmr_path, config_file=self.test_config_file)
 
         expected_globals = {
             'HDF5_GLOBAL': {
@@ -392,7 +393,7 @@ class TestVarInfoFromDmr(TestCase):
         variables.
 
         """
-        dataset = VarInfoFromDmr(self.mock_dmr_two, config_file=self.config_file)
+        dataset = VarInfoFromDmr(self.mock_dmr_two, config_file=self.test_config_file)
 
         expected_variables = {
             '/science/interesting_thing',
@@ -411,7 +412,7 @@ class TestVarInfoFromDmr(TestCase):
         associated instance of the `CFConfig` class.
 
         """
-        dataset = VarInfoFromDmr(self.mock_dmr_two, config_file=self.config_file)
+        dataset = VarInfoFromDmr(self.mock_dmr_two, config_file=self.test_config_file)
 
         science_variables = dataset.get_science_variables()
         self.assertEqual(science_variables, {'/science/interesting_thing'})
@@ -426,7 +427,7 @@ class TestVarInfoFromDmr(TestCase):
         excluded by the `CFConfig` instance.
 
         """
-        dataset = VarInfoFromDmr(self.mock_dmr_two, config_file=self.config_file)
+        dataset = VarInfoFromDmr(self.mock_dmr_two, config_file=self.test_config_file)
 
         metadata_variables = dataset.get_metadata_variables()
         self.assertSetEqual(metadata_variables, {'/required_group/has_no_coordinates'})
@@ -440,7 +441,7 @@ class TestVarInfoFromDmr(TestCase):
         subset_control_variables.
 
         """
-        dataset = VarInfoFromDmr(self.mock_dmr_two, config_file=self.config_file)
+        dataset = VarInfoFromDmr(self.mock_dmr_two, config_file=self.test_config_file)
 
         with self.subTest('All references to other variables are retrieved'):
             required_variables = dataset.get_required_variables(
@@ -510,7 +511,7 @@ class TestVarInfoFromDmr(TestCase):
         ensure `None` is returned.
 
         """
-        dataset = VarInfoFromDmr(self.mock_dmr_two, config_file=self.config_file)
+        dataset = VarInfoFromDmr(self.mock_dmr_two, config_file=self.test_config_file)
 
         with self.subTest('A variable with coordinates'):
             science_variable = dataset.get_variable('/science/interesting_thing')
@@ -566,7 +567,7 @@ class TestVarInfoFromDmr(TestCase):
         )
 
         dmr_path = write_dmr(self.output_dir, mock_dmr)
-        dataset = VarInfoFromDmr(dmr_path, config_file=self.config_file)
+        dataset = VarInfoFromDmr(dmr_path, config_file=self.test_config_file)
 
         with self.subTest('All dimensions are retrieved'):
             self.assertSetEqual(
@@ -595,7 +596,7 @@ class TestVarInfoFromDmr(TestCase):
 
         """
         dataset = VarInfoFromDmr(
-            self.mock_geo_and_projected_dmr, config_file=self.config_file
+            self.mock_geo_and_projected_dmr, config_file=self.test_config_file
         )
 
         with self.subTest('All horizontal spatial variables are returned'):
@@ -628,7 +629,7 @@ class TestVarInfoFromDmr(TestCase):
 
         """
         dataset = VarInfoFromDmr(
-            self.mock_geo_and_projected_dmr, config_file=self.config_file
+            self.mock_geo_and_projected_dmr, config_file=self.test_config_file
         )
 
         with self.subTest('All (and only) geographic variables are returned'):
@@ -667,7 +668,7 @@ class TestVarInfoFromDmr(TestCase):
 
         """
         dataset = VarInfoFromDmr(
-            self.mock_geo_and_projected_dmr, config_file=self.config_file
+            self.mock_geo_and_projected_dmr, config_file=self.test_config_file
         )
 
         with self.subTest('All (and only) projected dimension variables are returned'):
@@ -752,7 +753,7 @@ class TestVarInfoFromDmr(TestCase):
         )
 
         dmr_path = write_dmr(self.output_dir, mock_dmr)
-        dataset = VarInfoFromDmr(dmr_path, config_file=self.config_file)
+        dataset = VarInfoFromDmr(dmr_path, config_file=self.test_config_file)
 
         with self.subTest('All (and only) temporal variables are returned'):
             self.assertSetEqual(
@@ -787,7 +788,7 @@ class TestVarInfoFromDmr(TestCase):
 
         """
         dataset = VarInfoFromDmr(
-            self.mock_geo_and_projected_dmr, config_file=self.config_file
+            self.mock_geo_and_projected_dmr, config_file=self.test_config_file
         )
 
         with self.subTest('Only geographically gridded variables are retrieved'):
@@ -810,7 +811,7 @@ class TestVarInfoFromDmr(TestCase):
     def test_group_variables_by_dimensions(self):
         """Ensure all variables are grouped according to their dimensions."""
         dataset = VarInfoFromDmr(
-            self.dimension_grouping_dmr, config_file=self.config_file
+            self.dimension_grouping_dmr, config_file=self.test_config_file
         )
 
         expected_groups = {
@@ -841,7 +842,7 @@ class TestVarInfoFromDmr(TestCase):
 
         """
         dataset = VarInfoFromDmr(
-            self.dimension_grouping_dmr, config_file=self.config_file
+            self.dimension_grouping_dmr, config_file=self.test_config_file
         )
 
         expected_groups = {
@@ -874,7 +875,7 @@ class TestVarInfoFromDmr(TestCase):
 
         """
         netcdf4_path = write_skeleton_netcdf4(self.output_dir)
-        dataset = VarInfoFromNetCDF4(netcdf4_path, config_file=self.config_file)
+        dataset = VarInfoFromNetCDF4(netcdf4_path, config_file=self.test_config_file)
         self.assertSetEqual(
             dataset.get_science_variables(), {'/group/science2', '/science1'}
         )
@@ -912,7 +913,7 @@ class TestVarInfoFromDmr(TestCase):
 
         """
         dataset = VarInfoFromDmr(
-            self.mock_dmr_two, 'FAKE99', config_file=self.config_file
+            self.mock_dmr_two, 'FAKE99', config_file=self.test_config_file
         )
 
         with self.subTest('All CF attributes are retrieved for missing variable'):
@@ -931,7 +932,9 @@ class TestVarInfoFromDmr(TestCase):
 
         """
         dmr_path = 'tests/unit/data/GPM_3IMERGHH_example.dmr'
-        dataset = VarInfoFromDmr(dmr_path, 'GPM_3IMERGHH', config_file=self.config_file)
+        dataset = VarInfoFromDmr(
+            dmr_path, 'GPM_3IMERGHH', config_file=self.test_config_file
+        )
         with self.subTest('All coordinate references for a variable'):
             self.assertSetEqual(
                 dataset.get_references_for_attribute(

--- a/tests/unit/test_var_info.py
+++ b/tests/unit/test_var_info.py
@@ -249,7 +249,7 @@ class TestVarInfoFromDmr(TestCase):
         """Ensure VarInfo instantiates correctly, creating records of all the
         variables in the granule, and correctly deciding if they are
         science variables, metadata or references. This test uses a mission
-        and short name that do not have any CF overrides.
+        and short name that do not have any metadata overrides.
 
         """
         dataset = VarInfoFromDmr(
@@ -298,7 +298,7 @@ class TestVarInfoFromDmr(TestCase):
 
     def test_var_info_instantiation_cf_augmentation(self):
         """Ensure VarInfo instantiates correcly, using a missions that has
-        overrides in the CFConfig class.
+        metadata attribute overrides in the CFConfig class.
 
         """
         dataset = VarInfoFromDmr(self.mock_dmr_two, config_file=self.test_config_file)

--- a/varinfo/attribute_container.py
+++ b/varinfo/attribute_container.py
@@ -40,7 +40,7 @@ class AttributeContainerBase(ABC):
         """
         self.namespace = namespace
         self.full_name_path = full_name_path
-        self.cf_overrides = cf_config.get_cf_overrides(self.full_name_path)
+        self.metadata_overrides = cf_config.get_metadata_overrides(self.full_name_path)
         self.attributes = self._get_attributes(container)
         self._add_additional_attributes()
 
@@ -78,7 +78,7 @@ class AttributeContainerBase(ABC):
         be added to the variable metadata attributes.
 
         """
-        self._add_missing_attributes(self.cf_overrides)
+        self._add_missing_attributes(self.metadata_overrides)
 
     def _add_missing_attributes(self, extra_attributes: dict) -> None:
         """Iterate through a dictionary of attributes from the `CFConfig`
@@ -99,7 +99,7 @@ class AttributeContainerBase(ABC):
         value.
 
         """
-        return self.cf_overrides.get(attribute_name, raw_attribute_value)
+        return self.metadata_overrides.get(attribute_name, raw_attribute_value)
 
 
 class AttributeContainerFromDmr(AttributeContainerBase):

--- a/varinfo/cf_config.py
+++ b/varinfo/cf_config.py
@@ -57,7 +57,7 @@ class CFConfig:
         self.mission = mission
         self.short_name = collection_short_name
 
-        self.cf_overrides: dict[str, dict[str, Any]] = {}
+        self.metadata_overrides: dict[str, dict[str, Any]] = {}
         self.excluded_science_variables: set[str] = set()
         self.required_variables: set[str] = set()
 
@@ -100,8 +100,8 @@ class CFConfig:
             for pattern in item['VariablePattern']
         }
 
-        for override in config.get('CFOverrides', []):
-            self._process_cf_item(override, self.cf_overrides)
+        for override in config.get('MetadataOverrides', []):
+            self._process_cf_item(override, self.metadata_overrides)
 
     def _is_applicable(self, mission: str, short_name: str | None = None) -> bool:
         """Given a mission, and optionally also a collection short name, of an
@@ -125,7 +125,7 @@ class CFConfig:
         input_mission: str | None = None,
         input_short_name: str | None = None,
     ):
-        """Process a single block in the CF overrides region of the
+        """Process a single block in the `MetadataOverrides` region of the
         configuration file. First check that the applicability matches the
         mission and short name for the class. Next, check for a variable
         pattern. This is indicative of there being overriding attributes in
@@ -155,12 +155,13 @@ class CFConfig:
             for attribute in cf_item.get('Attributes', {})
         }
 
-    def get_cf_overrides(self, variable_path: str) -> dict[str, Any]:
-        """Return the CF overrides that match a given variable. If there are no
-        overrides, then empty dictionaries will be returned instead.
+    def get_metadata_overrides(self, variable_path: str) -> dict[str, Any]:
+        """Return the MetadataOverrides that match a given variable. If there
+        are no overrides, then empty dictionaries will be returned instead.
 
-        First iterate through the self.cf_overrides and find all items with a
-        variable pattern that matches the supplied variable (or group) path.
+        First iterate through the self.metadata_overrides and find all items
+        with a variable pattern that matches the supplied variable (or group)
+        path.
 
         Next sort that dictionary, so that matching patterns are:
 
@@ -182,11 +183,11 @@ class CFConfig:
         """
         matching_overrides = {
             pattern: attributes
-            for pattern, attributes in self.cf_overrides.items()
+            for pattern, attributes in self.metadata_overrides.items()
             if re.match(pattern, variable_path) is not None
         }
 
-        # Order override items by:
+        # Order MetadataOverrides items by:
         # First: Depth of the variable hierarchy included in the regular
         # expression pattern (number of slashes), shallowest to deepest.
         # Second: The length of the variable pattern, from shorted to longest.

--- a/varinfo/cf_config.py
+++ b/varinfo/cf_config.py
@@ -82,25 +82,25 @@ class CFConfig:
 
         self.excluded_science_variables = {
             pattern
-            for item in config.get('Excluded_Science_Variables', [])
+            for item in config.get('ExcludedScienceVariables', [])
             if self._is_applicable(
                 item['Applicability'].get('Mission'),
                 item['Applicability'].get('ShortNamePath'),
             )
-            for pattern in item['Variable_Pattern']
+            for pattern in item['VariablePattern']
         }
 
         self.required_variables = {
             pattern
-            for item in config.get('Required_Fields', [])
+            for item in config.get('RequiredVariables', [])
             if self._is_applicable(
                 item['Applicability'].get('Mission'),
                 item['Applicability'].get('ShortNamePath'),
             )
-            for pattern in item['Variable_Pattern']
+            for pattern in item['VariablePattern']
         }
 
-        for override in config.get('CF_Overrides', []):
+        for override in config.get('CFOverrides', []):
             self._process_cf_item(override, self.cf_overrides)
 
     def _is_applicable(self, mission: str, short_name: str | None = None) -> bool:
@@ -141,7 +141,7 @@ class CFConfig:
             # variable path - the assumption here is that the applicability is
             # to all variables (see ICESat2 dimensions override, SPL4.* and
             # SPL3FTA grid_mapping overrides)
-            pattern = cf_item['Applicability'].get('Variable_Pattern', '.*')
+            pattern = cf_item['Applicability'].get('VariablePattern', '.*')
             results[pattern] = self._create_attributes_object(cf_item)
 
     @staticmethod

--- a/varinfo/var_info.py
+++ b/varinfo/var_info.py
@@ -344,7 +344,7 @@ class VarInfoBase(ABC):
         variables would need to be in the configuration file.
 
         """
-        return self.cf_config.get_cf_overrides(variable_name)
+        return self.cf_config.get_metadata_overrides(variable_name)
 
     def get_references_for_attribute(
         self, list_of_variables: list[str], reference_attribute_name: str

--- a/varinfo/var_info.py
+++ b/varinfo/var_info.py
@@ -546,7 +546,7 @@ class VarInfoFromDmr(VarInfoBase):
                     self.dataset, short_name_path, self.namespace
                 )
                 for short_name_path in self.var_info_config.get(
-                    'Collection_ShortName_Path', []
+                    'CollectionShortNamePath', []
                 )
                 if get_full_path_xml_attribute(
                     self.dataset, short_name_path, self.namespace
@@ -669,7 +669,7 @@ class VarInfoFromNetCDF4(VarInfoBase):
                 (
                     get_full_path_netcdf4_attribute(dataset, short_name_path)
                     for short_name_path in self.var_info_config.get(
-                        'Collection_ShortName_Path', []
+                        'CollectionShortNamePath', []
                     )
                     if get_full_path_netcdf4_attribute(dataset, short_name_path)
                     is not None

--- a/varinfo/variable.py
+++ b/varinfo/variable.py
@@ -248,7 +248,7 @@ class VariableBase(AttributeContainerBase):
         fully qualified references is returned.
 
         """
-        dimensions_override = self.cf_overrides.get('dimensions')
+        dimensions_override = self.metadata_overrides.get('dimensions')
 
         if dimensions_override is not None:
             dimensions = re.split(r'\s+|,\s*', dimensions_override)


### PR DESCRIPTION
## Description

This PR performs the final clean-up relating to the recommendations for cleaning up the `earthdata-varinfo` configuration file schema (recommendations 4 to 7 [here](https://wiki.earthdata.nasa.gov/display/SITC/earthdata-varinfo+configuration+schema+v2.0.0+proposal)). Specifically:

* `Grid_Mapping_Data` is removed (as this information wasn't directly used, and can be included as metadata attributes in `CFOverrides`.
* `ProductEpochs` is removed (as this information wasn't directly used, and can be included as a `units` metadata attribute in the more CF Convention compliant manner via `CFOverrides`).
* The schema now uses `PascalCase` for all attributes of the schema.

This is mostly small stuff updates, and I think it closes out the last of the proposed schema changes.

## Jira Issue ID

TRT-556

## Local Test Steps

* Pull this branch.
* Pip install all the local dependencies.
* Try and parse a local NetCDF-4 or DMR file. It should all work.

```
# Install dependencies:
$ pip install -r requirements.txt

# Install this version of the package (optional, if running from the root of the directory):
$ pip install -e .

# Parse a file (with/without a configuration file, this is now in a Python repl):
> from varinfo import VarInfoFromNetCDF4
>
> vi_instance = VarInfoFromNetCDF4('path/to/file.nc4', short_name='<collection short name>', config_file='/path/to/config.json')
```

## PR Acceptance Checklist
* [x] Jira ticket acceptance criteria met.
* [x] `CHANGELOG.md` updated to include high level summary of PR changes.
* ~~`VERSION` updated if publishing a release.~~ (This is a feature branch)
* [x] Tests added/updated and passing.
* [x] Documentation updated (if needed).