### PR TITLE
IP-244 - Update actions/upload-artifact to v4 due to v3 deprecation.

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,13 +27,13 @@ jobs:
         run: make test
 
       - name: Archive test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test results for Python ${{ matrix.python-version }}
           path: tests/reports/earthdata-varinfo_junit.xml
 
       - name: Archive coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Coverage report for Python ${{ matrix.python-version }}
           path: tests/coverage/


### PR DESCRIPTION
## Description

I received a deprecation notice for one of the actions we use to upload artefacts during our CI/CD runs (coverage reports and JUnit style test results output).

For more information see [here](https://github.blog/changelog/2024-12-05-deprecation-notice-github-pages-actions-to-require-artifacts-actions-v4-on-github-com/#:~:text=On%20January%2030%2C%202025%2C%20the,improved%20performance%20and%20new%20features.).

I don't think there are any breaking changes as we only use very basic options for the action and use unique names for each artefact we upload (based on Python versions from the matrix).

## Jira Issue ID

N/A

## Local Test Steps

N/A (just check that the CI/CD runs for the PR and artefacts are uploaded when it does so)

## PR Acceptance Checklist

All are non-applicable. These changes are internal to our CI/CD workflows and will not require a release of any service code.

* ~~Jira ticket acceptance criteria met.~~
* ~~`CHANGELOG.md` updated to include high level summary of PR changes.~~
* ~~`VERSION` updated if publishing a release.~~
* ~~Tests added/updated and passing.~~
* ~~Documentation updated (if needed).~~