### PR TITLE
TRT-552 - Addendum to clarify pattern matching documentation.

### DIFF
--- a/varinfo/cf_config.py
+++ b/varinfo/cf_config.py
@@ -165,8 +165,8 @@ class CFConfig:
 
         Next sort that dictionary, so that matching patterns are:
 
-        * Primarily sorted from shallowed to deepest, by counting the number of
-          slashes in the string.
+        * Primarily sorted from shallowed to deepest, by counting the total
+          number of slashes in the string.
         * Within each depth (with the same number of slashes), patterns are
           sorted from shortest to longest string length.
 
@@ -179,6 +179,25 @@ class CFConfig:
         are multiple values supplied for the same metadata attribute, the value
         retained will be the one with the longest variable pattern, which is a
         proxy for how specific the override is.
+
+        Note: Depth is approximated by counting the _total_ number of slashes
+        in the VariablePattern regular expression, and does not account for
+        alternation. As such:
+
+        ```
+        "Applicability": {
+          "VariablePattern": "/(group_one|group_two)/.*
+        }
+        ```
+
+        will correctly determine a depth of 2, whereas:
+
+        ```
+        "Applicability": {
+          "VariablePattern": "(/group_one/.*|/group_two/.*)"
+        }
+        ```
+        will incorrectly determine a depth of 4.
 
         """
         matching_overrides = {


### PR DESCRIPTION
## Description

This PR came out of a conversation with @D-Auty and @sudha-murthy. Care needs to be taken with the regular expressions used for `VariablePattern`. Depth is estimated by counting the total number of slashes in the supplied regular expression. If there is alternation in the regular expression, it is possible to express multiple alternates each with slashes in them, and therefore overestimate the depth of the pattern.

This PR clarifies this distinction in the documentation string outlining the pattern matching algorithm.

## Jira Issue ID

TRT-552 - I'm using this issue as the current algorithm was implemented during that work.

## Local Test Steps

Just a documentation update, so please read and ensure the new content makes sense.

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* ~~`CHANGELOG.md` updated to include high level summary of PR changes.~~ (No changes requiring CHANGELOG updates)
* ~~`VERSION` updated if publishing a release.~~ No release needed.
* ~~Tests added/updated and passing.~~ No code changes.
* [x] Documentation updated (if needed).