### PR TITLE
DAS-2339 - Clarify RequiredVariables documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v3.1.1
+### Unreleased
+
+### Changed:
+
+* DAS-2339 - Clarified documentation regarding `RequiredVariables` in the
+  configuration file schema, `CFConfig` class and
+  `VarInfoBase.get_required_variables`. Variables specified in
+  `RequiredVariables` will be included as required variables for all variables
+  variable subsets of the relevant collection defined in the configuration file
+  rule. There is no filtering based on the variable path of the requested
+  variables in the input set to `VarInfoBase.get_required_variables`.
+
 ## v3.1.0
 ### 2025-03-25
 

--- a/config/1.0.0/earthdata_varinfo_configuration_schema.json
+++ b/config/1.0.0/earthdata_varinfo_configuration_schema.json
@@ -37,14 +37,14 @@
       }
     },
     "RequiredVariables": {
-      "description": "# VarInfo classes will calculate a set of required variables for a given science variable. This setting imposes additional contents for the required variables list.",
+      "description": "VarInfo classes will calculate a set of required variables for a given science variable. This setting imposes additional contents for the required variables list that apply to all variables in a collection.",
       "type": "array",
       "items": {
         "$ref": "#/$defs/MissionVariablePatternType"
       }
     },
     "MetadataOverrides": {
-      "description": "# For cases where CF references do not exist, or are invalid. For example, variables that have no dimension references in the HDF-5 file contents",
+      "description": "For cases where CF references do not exist, or are invalid. For example, variables that have no dimension references in the HDF-5 file contents",
       "type": "array",
       "items": {
         "$ref": "#/$defs/MetadataOverridesItemType"

--- a/varinfo/cf_config.py
+++ b/varinfo/cf_config.py
@@ -69,6 +69,11 @@ class CFConfig:
         of it pertaining to the mission and collection specified upon
         instantiating the class.
 
+        Note: Applicable rules for `RequiredVariables` will be applied to all
+        variables in a collection when trying to identify required variables
+        for a given subset of requested variables. The `VariablePattern` of
+        the `ApplicabilityType` is not taken into account.
+
         """
         if self.config_file is not None and not exists(self.config_file):
             raise MissingConfigurationFileError(self.config_file)

--- a/varinfo/var_info.py
+++ b/varinfo/var_info.py
@@ -288,6 +288,11 @@ class VarInfoBase(ABC):
         variables for the collection, as indicated by the CFConfig class
         instance, and any references within those variables.
 
+        All variables included within the `CFConfig.required_variables` instance
+        attribute will be included in any request for required variables. There
+        is no pattern matching applied from the `ApplicabilityType` for the
+        items in the `RequiredVariables` section of the configuration file.
+
         """
         if self.cf_config.required_variables:
             cf_required_pattern = re.compile(


### PR DESCRIPTION
## Description

This topic arose during implementation for changes within HOSS to have required variables. This PR attempts to clarify the behaviour of items specified within the `RequiredVariables` section of the `earthdata-varinfo` configuration file. Namely: things listed as `RequiredVariables` there are considered required for _all_ variables in the relevant collection. Even though the schema allows for a `VariablePattern` in the `ApplicabilityType`, that is not taken into consideration.

There are no code changes here, so I have not incremented the version of `earthdata-varinfo` for a release. Similarly: the schema file has technically changed, but it's just changes to the descriptions of fields, not changes to the structure of the schema, so I have not incremented the schema version either.

## Jira Issue ID

DAS-2339 (in support of)

## Local Test Steps

* N/A - just a documentation change.

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~ - This is a documentation change that came out of DAS-2339, it is not implementing that ticket.
* [x] `CHANGELOG.md` updated to include high level summary of PR changes.
* ~~`VERSION` updated if publishing a release.~~ - No actual code changes. So no release.
* ~~Tests added/updated and passing.~~ No code change, so no test changes.
* [x] Documentation updated (if needed).