### PR TITLE
TRT-315: Include commit history in release notes.

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -22,7 +22,9 @@ jobs:
 
     steps:
       - name: Checkout earthdata-varinfo repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v4

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout earthdata-varinfo repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
-## v3.3.0
-### 2025-09-11
+# Changelog
+
+earthdata-varinfo follows semantic versioning. All notable changes to this
+project will be documented in this file. The format is based on
+[Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+## [vX.Y.Z] - Unreleased
+
+### Changed:
+
+* Release notes for `earthdata-varinfo` will now include the commit history for
+  that release.
+
+## [v3.3.0] - 2025-09-11
 
 ### Changed:
 
@@ -7,8 +19,7 @@
   to first consider the `netCDF4.Variable.datatype.name` and then fall back to
   `netCDF4.Variable.datatype.dtype`.
 
-## v3.2.0
-### 2025-07-25
+## [v3.2.0] - 2025-07-25
 
 ### Changed:
 
@@ -25,8 +36,7 @@
 * Support for getting an OPeNDAP url with `cmr_search.get_dmr_xml_url` and
   a `use_dmr=True` flag to `varinfo/generate_umm_var.generate_collection_umm_var`
 
-## v3.1.0
-### 2025-03-25
+## [v3.1.0] - 2025-03-25
 
 ### Added:
 
@@ -37,15 +47,13 @@
 
 * earthdata-varinfo's numpy requirements relaxed to allow numpy v2.
 
-## v3.0.3
-### 2025-03-21
+## [v3.0.3] - 2025-03-21
 
 ### Changed:
 
 * Updated to `netCDF4~=1.7.2` to enable `mypy` type hints for the package.
 
-## v3.0.2
-### 2025-02-07
+## [v3.0.2] - 2025-02-07
 
 This version of `earthdata-varinfo` enables support for `VariableFromDmr`
 variable dimension shape data in NetCDF-4 files with named dimensions
@@ -59,8 +67,7 @@ files with named dimensions and HDF-5 files with anonymous size-only dimensions.
 
 * Update DMR `unittest` to validate variable dimension shape data.
 
-## v3.0.1
-### 2024-10-18
+## [v3.0.1] - 2024-10-18
 
 ### Changed:
 
@@ -79,8 +86,7 @@ files with named dimensions and HDF-5 files with anonymous size-only dimensions.
   The CI/CD for running the tests has been updated to also run the tests under
   Python 3.12.
 
-## v3.0.0
-### 2024-09-11
+## [v3.0.0] - 2024-09-11
 
 The configuration file schema for `earthdata-varinfo` is significantly updated
 in this release. For more information, see the release notes for schema v1.0.0
@@ -114,8 +120,7 @@ an input file.
   in-file metadata changes via a `MetadataOverrides` item (formerly
   `CFOverrides`) instead.
 
-## v2.3.0
-### 2024-08-26
+## [v2.3.0] - 2024-08-26
 
 The `VarInfoBase.get_missing_variable_attributes` method has been added to allow
 someone to get metadata attributes from the configuration file for variables
@@ -126,21 +131,19 @@ all unique variable references contained in a single metadata attribute for a
 list of variables. For example, retrieving all references listed under the
 coordinates metadata attribute.
 
-## v2.2.2
-### 2024-07-16
+## [v2.2.2] - 2024-07-16
 
 The `generate_collection_umm_var` function in earthdata-varinfo updated to
 support an optional kwarg `config_file` for a configuration file, to be able to
 override known metadata errors.
 
 
-## v2.2.1
+## [v2.2.1] - 2024-04-06
 
 The `requests` package has been added as an explicit dependency of the package.
 Additionally, black code formatting has been applied to the entire repository.
 
-## v2.2.0
-### 2023-11-30
+## [v2.2.0] - 2023-11-30
 
 This version of `earthdata-varinfo` updates `varinfo.cmr_search` to include
 functionality to get a users EDL token given a LaunchPad token with
@@ -149,8 +152,7 @@ functionality to get a users EDL token given a LaunchPad token with
 token and CMR environment and `get_edl_token_header` returns the appropriate header
 prefix for each respective token.
 
-## v2.1.2
-### 2023-11-14
+## [v2.1.2] - 2023-11-14
 
 This version of `earthdata-varinfo` updates the value of the `LongName`
 attribute in generated UMM-Var records to use the value of the CF-Convention
@@ -158,13 +160,11 @@ attribute in generated UMM-Var records to use the value of the CF-Convention
 attribute is not present in the in-file metadata, then the full path to the
 variable (without the leading `/`) is used as before.
 
-## v2.1.1
-### 2023-10-24
+## [v2.1.1] - 2023-10-24
 
 Fixed deployment issues
 
-## v2.1.0
-### 2023-10-20
+## [v2.1.0] - 2023-10-20
 
 This version of `earthdata-varinfo` improves the functionality of the
 `varinfo.get_science_variables` function with `varinfo.is_science_variable()` method.
@@ -174,8 +174,7 @@ or grid mapping attribute variables. This version also updates `umm_var.get_umm_
 with `get_umm_var_type`. This function adds the UMM-Var field "VariableType"
 to a UMM-Var record if a variable is a science variable.
 
-## v2.0.0
-### 2023-09-15
+## [v2.0.0] - 2023-09-15
 
 This version of `earthdata-varinfo` adds functionality to publish records to
 CMR, along with a single overarching function that wraps the search, download
@@ -193,8 +192,7 @@ compatible with LaunchPad tokens.
 * `umm_var.publish_all_umm_var` ingests all of the UMM-Var entries from a given
   collection to CMR
 
-## v1.0.1
-### 2023-08-28
+## [v1.0.1] - 2023-08-28
 
 This version of `earthdata-varinfo` includes preliminary functionality to
 streamline the process of creating UMM-Var records given information about a
@@ -204,8 +202,7 @@ collection in CMR:
 * Added function `download_granule` to `cmr_search.py`, to download a granule
   from a specified URL.
 
-## v1.0.0
-### 2023-06-16
+## [v1.0.0] - 2023-06-16
 
 This version of `earthdata-varinfo` contains all functionality previous
 released as `sds-varinfo==4.1.1`, but resets the version number to begin
@@ -215,3 +212,21 @@ to the repository include updated documentation and files outlined by the
 
 For more information on internal releases prior to NASA open-source approval,
 see `legacy-CHANGELOG.md`.
+
+[v3.3.0]: https://github.com/nasa/earthdata-varinfo/releases/tag/3.3.0
+[v3.2.0]: https://github.com/nasa/earthdata-varinfo/releases/tag/3.2.0
+[v3.1.0]: https://github.com/nasa/earthdata-varinfo/releases/tag/3.1.0
+[v3.0.3]: https://github.com/nasa/earthdata-varinfo/releases/tag/3.0.3
+[v3.0.2]: https://github.com/nasa/earthdata-varinfo/releases/tag/3.0.2
+[v3.0.1]: https://github.com/nasa/earthdata-varinfo/releases/tag/3.0.1
+[v3.0.0]: https://github.com/nasa/earthdata-varinfo/releases/tag/3.0.0
+[v2.3.0]: https://github.com/nasa/earthdata-varinfo/releases/tag/2.3.0
+[v2.2.2]: https://github.com/nasa/earthdata-varinfo/releases/tag/2.2.2
+[v2.2.1]: https://github.com/nasa/earthdata-varinfo/releases/tag/2.2.1
+[v2.2.0]: https://github.com/nasa/earthdata-varinfo/releases/tag/2.2.0
+[v2.1.2]: https://github.com/nasa/earthdata-varinfo/releases/tag/2.1.2
+[v2.1.1]: https://github.com/nasa/earthdata-varinfo/releases/tag/2.1.1
+[v2.1.0]: https://github.com/nasa/earthdata-varinfo/releases/tag/2.1.0
+[v2.0.0]: https://github.com/nasa/earthdata-varinfo/releases/tag/2.0.0
+[v1.0.1]: https://github.com/nasa/earthdata-varinfo/releases/tag/1.0.1
+[v1.0.0]: https://github.com/nasa/earthdata-varinfo/releases/tag/1.0.0

--- a/bin/extract-release-notes.sh
+++ b/bin/extract-release-notes.sh
@@ -5,17 +5,46 @@
 # earthdata-varinfo from CHANGELOG.md
 #
 # 2023-06-16: Created
+# 2025-09-22: Append git commit messages to release notes.
 #
 ###############################################################################
 
 CHANGELOG_FILE="CHANGELOG.md"
-VERSION_PATTERN="^## v"
-# Count number of versions in version file:
-number_of_versions=$(grep -c "${VERSION_PATTERN}" ${CHANGELOG_FILE})
 
-if [ ${number_of_versions} -gt 1 ]
+## captures versions
+## >## v1.0.0
+## >## [v1.0.0]
+VERSION_PATTERN="^## [\[]v"
+
+## captures url links
+## [v1.2.0]: https://github.com/nasa/earthdata-varinfo/releases/tags/1.2.0
+LINK_PATTERN="^\[.*\]:.*https://github.com/nasa"
+
+# Read the file and extract text between the first two occurrences of the
+# VERSION_PATTERN
+result=$(awk "/$VERSION_PATTERN/{c++; if(c==2) exit;} c==1" "$CHANGELOG_FILE")
+
+# Get all commit messages since the last release (marked with a git tag). If
+# there are no tags, get the full commit history of the repository.
+if [[ $(git tag) ]]
 then
-	grep -B 9999 -m 2 "${VERSION_PATTERN}" ${CHANGELOG_FILE} | sed '$d' | sed '$d'
+	# There are git tags, so get the most recent one
+	GIT_REF=$(git describe --tags --abbrev=0)
 else
-	cat ${CHANGELOG_FILE}
+	# There are not git tags, so get the initial commit of the repository
+	GIT_REF=$(git rev-list --max-parents=0 HEAD)
 fi
+
+# Retrieve the title line of all commit messages since $GIT_REF, filtering out
+# those from the pre-commit-ci[bot] author and any containing the string
+# "nasa/pre-commit-ci-update-config", which may result from merge commits.
+GIT_COMMIT_MESSAGES=$(git log --oneline --format="%s" --perl-regexp --author='^(?!pre-commit-ci\[bot\]).*$' --grep="nasa\/pre-commit-ci-update-config" --invert-grep ${GIT_REF}..HEAD)
+
+# Append git commit messages to the release notes:
+if [[ ${GIT_COMMIT_MESSAGES} ]]
+then
+	result+="\n\n## Commits\n\n${GIT_COMMIT_MESSAGES}"
+fi
+
+# Print the result
+echo -e "$result" |  grep -v "$VERSION_PATTERN" | grep -v "$LINK_PATTERN"


### PR DESCRIPTION
## Description

This PR updates the generation of release notes to include the commit history for the release. This is in response to NSIDC wanting an easier way to map between releases and the work included in them.

I've also made sure the `CHANGELOG.md` now matches the format of others, so the script extracting releases works as expected.

## Jira Issue ID

TRT-315 (and other NSIDC verification related tickets)

## Local Test Steps

* Pull this branch.
* Run `bin/extract-release-notes.sh` to ensure the most recent release notes are extracted.

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* [x] `CHANGELOG.md` updated to include high level summary of PR changes.
* ~~`VERSION` updated if publishing a release.~~ (Just an update to CI/CD)
* ~~Tests added/updated and passing.~~
* ~~Documentation updated (if needed).~~