### PR TITLE
IP-254: Add pytest-cov minimum threshold of 95%.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ prepare-test:
 	mkdir -p tests/reports tests/coverage
 
 test: prepare-test
-	pytest --junitxml=tests/reports/earthdata-varinfo_junit.xml --cov varinfo --cov-report html:tests/coverage --cov-report term --cov-fail-under=90
+	pytest --junitxml=tests/reports/earthdata-varinfo_junit.xml --cov varinfo --cov-report html:tests/coverage --cov-report term --cov-fail-under=95

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ $ make test
 ```
 
 Note, the test execution will fail if code coverage of unit tests falls below
-90%.
+95%. This threshold is also used during the GitHub workflow CI/CD.
 
 ### pre-commit hooks:
 


### PR DESCRIPTION
## Description

This PR is a process improvement that implements the `--cov-fail-under` option from `pytest-cov`, so that `pytest` will fail the unit test suite if the overall coverage of the project falls below 95%. Execution of the tests will include additional logging, such as:

```
Required test coverage of 95% reached. Total coverage: 99.07%
```

or:

```
FAIL Required test coverage of 95% not reached. Total coverage: 82.94%
```

In the latter case, the tests suite will end in a failed state.

The number usually bandied about for code coverage by unit tests is 80%. I initially chose 90% because we're starting off at a healthy 99.07%. After chatting with @flamingbear, we settled on 95%, which is more aggressive, but the current coverage is well clear of that bar. I'd still like to hear what other folks think. (Note - this will only consider the overall coverage percentage, not something more fancy like the percentage of updated code in a PR covered)

## Jira Issue ID

N/A (leftover IP sprint work)

## Local Test Steps

* Pull this branch.
* Create a local Python environment.
* Install dependencies: `make install`
* Run the tests: `make test` - you should see the logged message of meeting the required test coverage (see first example above).
* Delete a couple test files. Then re-run the tests. When you have deleted enough test files, you will get below 95% code coverage, and see the second type of logged message, and the `make test` command will exit in an `Error 1` state. (This is the same state the `make test` command ends with if a unit test fails)

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* ~~`CHANGELOG.md` updated to include high level summary of PR changes.~~
* ~~`VERSION` updated if publishing a release.~~
* [x] Tests added/updated and passing.
* [x] Documentation updated (if needed).