### PR TITLE
DAS-NONE: Update CI/CD Python versions.

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
       fail-fast: false
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     install_requires=parse_dependencies('requirements.txt'),
     extras_require={'dev': parse_dependencies('dev-requirements.txt')},
     test_suite='tests',
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     license='License :: OSI Approved :: Apache Software License',
     classifiers=[
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,11 @@ setup(
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Operating System :: OS Independent',
     ],
 )


### PR DESCRIPTION
## Description

This PR removes Python 3.9 from the CI/CD, as it was EOL on 31st October 2025. It also adds Python 3.13 and Python 3.14 to the CI/CD, which are currently available versions of Python we should be testing.

I also added labels to the package `setup.py` to indicate the versions of Python that `earthdata-varinfo` can run in. I don't think this should be a version release on it's own, but should get folded in to 4.1.2 and deployed with #103.

## Jira Issue ID

N/A

## Local Test Steps

Create local conda/virtualenv environments under Python 3.13  and 3.14. Then:

```
pip install -r requirements.txt -r dev-requirements.txt
make test
```

The tests should all pass.


## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* ~~`CHANGELOG.md` updated to include high level summary of PR changes.~~
* ~~`VERSION` updated if publishing a release.~~
* [x] Tests added/updated and passing.
* ~~Documentation updated (if needed).~~