### PR TITLE
TRT-NA: Update CI/CD to use latest action versions.

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: Checkout earthdata-varinfo repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout earthdata-varinfo repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -27,13 +27,13 @@ jobs:
         run: make test
 
       - name: Archive test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Test results for Python ${{ matrix.python-version }}
           path: tests/reports/earthdata-varinfo_junit.xml
 
       - name: Archive coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Coverage report for Python ${{ matrix.python-version }}
           path: tests/coverage/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 ci:
   autofix_prs: false
+  autoupdate_schedule: monthly
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0


### PR DESCRIPTION
## Description

This is just repo maintenance... I was checking [the workflow that deployed v5.1.2](https://github.com/nasa/earthdata-varinfo/actions/runs/34526904749) following #110, and realised it was using the old version of `actions/upload-artifact` which leads to the deprecation warning about Node.js v20 runners. I bumped the version of the main GitHub actions. I also dialled down the frequency of the `pre-commit.ci` auto PRs to bump dependencies, following a similar change by @flamingbear. They will now be monthly, which seems manageable.

## Jira Issue ID

N/A - this is a repo chore.

## Local Test Steps

* Check that the three actions I've updated to checkout the repo, setup Python, and upload artefacts actually have those versions.
* Check that the CI/CD executing the tests for this PR completes without errors.

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* ~~`CHANGELOG.md` updated to include high level summary of PR changes.~~
* ~~`VERSION` updated if publishing a release.~~
* ~~Tests added/updated and passing.~~
* ~~Documentation updated (if needed).~~